### PR TITLE
Fix error when optional node/fex interfaces key is not present

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,12 +36,12 @@ locals {
       type = pg.type
       node_ids = [
         for node in try(local.interface_policies.nodes, []) :
-        node.id if length([for int in node.interfaces : try(int.policy_group, null) if try(int.policy_group, null) == pg.name]) > 0
+        node.id if length([for int in try(node.interfaces, []) : try(int.policy_group, null) if try(int.policy_group, null) == pg.name]) > 0
       ]
       fex_ids = flatten([
         for node in try(local.interface_policies.nodes, []) : [
           for fex in try(node.fexes, []) :
-          fex.id if length([for int in fex.interfaces : try(int.policy_group, null) if try(int.policy_group, null) == pg.name]) > 0
+          fex.id if length([for int in try(fex.interfaces, []) : try(int.policy_group, null) if try(int.policy_group, null) == pg.name]) > 0
         ]
       ])
     }


### PR DESCRIPTION
Example of error:

```
Error: Unsupported attribute

  on /modules/aci/main.tf line 39, in locals:
  39:         node.id if length([for int in node.interfaces : try(int.policy_group, null) if try(int.policy_group, null) == pg.name]) > 0

This object does not have an attribute named "interfaces".
```

Data model triggering error:

```
apic:
  interface_policies:
    nodes:
      - id: 101
```

Workaround is to add empty interfaces key however the preference is to update the code given the interfaces key is not mandatory in the data model schema, and a similar try statement exists for these keys on lines 14 and 15.

Workaround:

```
apic:
  interface_policies:
    nodes:
      - id: 101
        interfaces: []
```