### PR TITLE
Fix access leaf interface policy group name variable validation

### DIFF
--- a/modules/terraform-aci-access-leaf-interface-policy-group/variables.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/variables.tf
@@ -3,7 +3,7 @@ variable "name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.-:]{0,64}$", var.name))
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
   }
 }

--- a/modules/terraform-aci-endpoint-group/variables.tf
+++ b/modules/terraform-aci-endpoint-group/variables.tf
@@ -480,7 +480,7 @@ variable "static_ports" {
 
   validation {
     condition = alltrue([
-      for sp in var.static_ports : sp.channel == null || can(regex("^[a-zA-Z0-9_.-:]{0,64}$", sp.channel))
+      for sp in var.static_ports : sp.channel == null || can(regex("^[a-zA-Z0-9_.:-]{0,64}$", sp.channel))
     ])
     error_message = "`channel`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
   }

--- a/modules/terraform-aci-l3out-interface-profile/variables.tf
+++ b/modules/terraform-aci-l3out-interface-profile/variables.tf
@@ -316,7 +316,7 @@ variable "interfaces" {
 
   validation {
     condition = alltrue([
-      for i in var.interfaces : i.channel == null || try(can(regex("^[a-zA-Z0-9_.-:]{0,64}$", i.channel)), false)
+      for i in var.interfaces : i.channel == null || try(can(regex("^[a-zA-Z0-9_.:-]{0,64}$", i.channel)), false)
     ])
     error_message = "`channel`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
   }
@@ -372,7 +372,7 @@ variable "interfaces" {
 
   validation {
     condition = alltrue(flatten([
-      for i in var.interfaces : [for p in coalesce(i.paths, []) : p.physical_domain == null || try(can(regex("^[a-zA-Z0-9_.-:]{0,64}$", p.physical_domain)))]
+      for i in var.interfaces : [for p in coalesce(i.paths, []) : p.physical_domain == null || try(can(regex("^[a-zA-Z0-9_.:-]{0,64}$", p.physical_domain)))]
     ]))
     error_message = "`paths.physical_domain`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
   }


### PR DESCRIPTION
For a reason unknown to me, the order of the `:` and `-` need to be swapped otherwise a name containing the `-` character will fail the validation.