### PR TITLE
Make L3 PBR destination MAC optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1 (unreleased)
+
+- Make L3 PBR destination MAC optional
+
 ## 0.8.0
 
 - Fix replacement of placeholders in auto-generated objects

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -2808,7 +2808,7 @@ locals {
           description           = try(dest.description, "")
           ip                    = dest.ip
           ip_2                  = try(dest.ip_2, null)
-          mac                   = dest.mac
+          mac                   = try(dest.mac, null)
           redirect_health_group = try("${dest.redirect_health_group}${local.defaults.apic.tenants.services.redirect_health_groups.name_suffix}", "")
         }]
       }

--- a/modules/terraform-aci-redirect-policy/README.md
+++ b/modules/terraform-aci-redirect-policy/README.md
@@ -71,7 +71,7 @@ module "aci_redirect_policy" {
 | <a name="input_threshold_down_action"></a> [threshold\_down\_action](#input\_threshold\_down\_action) | Threshold down action. Choices: `permit`, `deny`, `bypass`. | `string` | `"permit"` | no |
 | <a name="input_ip_sla_policy"></a> [ip\_sla\_policy](#input\_ip\_sla\_policy) | IP SLA Policy Name. | `string` | `""` | no |
 | <a name="input_redirect_backup_policy"></a> [redirect\_backup\_policy](#input\_redirect\_backup\_policy) | Redirect Backup Policy Name. | `string` | `""` | no |
-| <a name="input_l3_destinations"></a> [l3\_destinations](#input\_l3\_destinations) | List of L3 destinations. Allowed values `pod`: 1-255. | <pre>list(object({<br>    description           = optional(string, "")<br>    ip                    = string<br>    ip_2                  = optional(string)<br>    mac                   = string<br>    pod_id                = optional(number, 1)<br>    redirect_health_group = optional(string, "")<br>  }))</pre> | `[]` | no |
+| <a name="input_l3_destinations"></a> [l3\_destinations](#input\_l3\_destinations) | List of L3 destinations. Allowed values `pod`: 1-255. | <pre>list(object({<br>    description           = optional(string, "")<br>    ip                    = string<br>    ip_2                  = optional(string)<br>    mac                   = optional(string)<br>    pod_id                = optional(number, 1)<br>    redirect_health_group = optional(string, "")<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-redirect-policy/main.tf
+++ b/modules/terraform-aci-redirect-policy/main.tf
@@ -43,7 +43,7 @@ resource "aci_rest_managed" "vnsRedirectDest" {
     descr = each.value.description
     ip    = each.value.ip
     ip2   = each.value.ip_2 != null ? each.value.ip_2 : "0.0.0.0"
-    mac   = each.value.mac
+    mac   = each.value.mac != null ? each.value.mac : "00:00:00:00:00:00"
     podId = each.value.pod_id
   }
 }

--- a/modules/terraform-aci-redirect-policy/variables.tf
+++ b/modules/terraform-aci-redirect-policy/variables.tf
@@ -145,7 +145,7 @@ variable "l3_destinations" {
     description           = optional(string, "")
     ip                    = string
     ip_2                  = optional(string)
-    mac                   = string
+    mac                   = optional(string)
     pod_id                = optional(number, 1)
     redirect_health_group = optional(string, "")
   }))


### PR DESCRIPTION
Since APIC v5.2, the L3 PBR destination MAC address is optional if an IP SLA policy is assigned. This change makes the MAC address optional to support this use case.