### PR TITLE
AP routed domain input validation needs to be updated to make vlan_pool an optional value

### DIFF
--- a/aci_access_policies.tf
+++ b/aci_access_policies.tf
@@ -33,10 +33,9 @@ module "aci_routed_domain" {
 
   for_each             = { for rd in try(local.access_policies.routed_domains, []) : rd.name => rd if local.modules.aci_routed_domain && var.manage_access_policies }
   name                 = "${each.value.name}${local.defaults.apic.access_policies.routed_domains.name_suffix}"
-  vlan_pool            = "${each.value.vlan_pool}${local.defaults.apic.access_policies.vlan_pools.name_suffix}"
+  vlan_pool            = try("${each.value.vlan_pool}${local.defaults.apic.access_policies.routed_domains.name_suffix}", "")
   vlan_pool_allocation = [for vp in try(local.access_policies.vlan_pools, []) : try(vp.allocation, local.defaults.apic.access_policies.vlan_pools.allocation) if vp.name == each.value.vlan_pool][0]
   security_domains     = try(each.value.security_domains, [])
-
   depends_on = [
     module.aci_vlan_pool,
   ]

--- a/modules/terraform-aci-aaep/README.md
+++ b/modules/terraform-aci-aaep/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # Terraform ACI AAEP Module
 
-Manages ACI Attachable Access Entity Profile
+Manages ACI Attachable Access Entity Profile 
 
 Location in GUI:
 `Fabric` » `Access Policies` » `Policies` » `Global` » `Attachable Access Entity Profiles`

--- a/modules/terraform-aci-aaep/README.md
+++ b/modules/terraform-aci-aaep/README.md
@@ -1,7 +1,7 @@
 <!-- BEGIN_TF_DOCS -->
 # Terraform ACI AAEP Module
 
-Manages ACI Attachable Access Entity Profile 
+Manages ACI Attachable Access Entity Profile
 
 Location in GUI:
 `Fabric` » `Access Policies` » `Policies` » `Global` » `Attachable Access Entity Profiles`

--- a/modules/terraform-aci-access-span-filter-group/README.md
+++ b/modules/terraform-aci-access-span-filter-group/README.md
@@ -4,7 +4,7 @@
 Manages ACI Access SPAN Filter Group
 
 Location in GUI:
-`Fabric` » `Access Policies` » `Policies` » `Troubleshooting` » `SPAN` » `SPAN Filter Groups` 
+`Fabric` » `Access Policies` » `Policies` » `Troubleshooting` » `SPAN` » `SPAN Filter Groups`
 
 ## Examples
 

--- a/modules/terraform-aci-access-span-filter-group/README.md
+++ b/modules/terraform-aci-access-span-filter-group/README.md
@@ -4,7 +4,7 @@
 Manages ACI Access SPAN Filter Group
 
 Location in GUI:
-`Fabric` » `Access Policies` » `Policies` » `Troubleshooting` » `SPAN` » `SPAN Filter Groups`
+`Fabric` » `Access Policies` » `Policies` » `Troubleshooting` » `SPAN` » `SPAN Filter Groups` 
 
 ## Examples
 

--- a/modules/terraform-aci-routed-domain/README.md
+++ b/modules/terraform-aci-routed-domain/README.md
@@ -38,7 +38,7 @@ module "aci_routed_domain" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Routed domain name. | `string` | n/a | yes |
-| <a name="input_vlan_pool"></a> [vlan\_pool](#input\_vlan\_pool) | Vlan pool name. | `string` | n/a | no |
+| <a name="input_vlan_pool"></a> [vlan\_pool](#input\_vlan\_pool) | Vlan pool name. | `string` | `""` | no |
 | <a name="input_vlan_pool_allocation"></a> [vlan\_pool\_allocation](#input\_vlan\_pool\_allocation) | Vlan pool allocation mode. Choices: `static`, `dynamic`. | `string` | `"static"` | no |
 | <a name="input_security_domains"></a> [security\_domains](#input\_security\_domains) | Security domains associated to routed domain | `list(string)` | `[]` | no |
 

--- a/modules/terraform-aci-routed-domain/README.md
+++ b/modules/terraform-aci-routed-domain/README.md
@@ -38,7 +38,7 @@ module "aci_routed_domain" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Routed domain name. | `string` | n/a | yes |
-| <a name="input_vlan_pool"></a> [vlan\_pool](#input\_vlan\_pool) | Vlan pool name. | `string` | n/a | yes |
+| <a name="input_vlan_pool"></a> [vlan\_pool](#input\_vlan\_pool) | Vlan pool name. | `string` | n/a | no |
 | <a name="input_vlan_pool_allocation"></a> [vlan\_pool\_allocation](#input\_vlan\_pool\_allocation) | Vlan pool allocation mode. Choices: `static`, `dynamic`. | `string` | `"static"` | no |
 | <a name="input_security_domains"></a> [security\_domains](#input\_security\_domains) | Security domains associated to routed domain | `list(string)` | `[]` | no |
 

--- a/modules/terraform-aci-routed-domain/main.tf
+++ b/modules/terraform-aci-routed-domain/main.tf
@@ -7,6 +7,7 @@ resource "aci_rest_managed" "l3extDomP" {
 }
 
 resource "aci_rest_managed" "infraRsVlanNs" {
+  count = var.vlan_pool != "" ? 1 : 0
   dn         = "${aci_rest_managed.l3extDomP.dn}/rsvlanNs"
   class_name = "infraRsVlanNs"
   content = {

--- a/modules/terraform-aci-routed-domain/main.tf
+++ b/modules/terraform-aci-routed-domain/main.tf
@@ -7,7 +7,7 @@ resource "aci_rest_managed" "l3extDomP" {
 }
 
 resource "aci_rest_managed" "infraRsVlanNs" {
-  count = var.vlan_pool != "" ? 1 : 0
+  count      = var.vlan_pool != "" ? 1 : 0
   dn         = "${aci_rest_managed.l3extDomP.dn}/rsvlanNs"
   class_name = "infraRsVlanNs"
   content = {

--- a/modules/terraform-aci-routed-domain/variables.tf
+++ b/modules/terraform-aci-routed-domain/variables.tf
@@ -11,7 +11,7 @@ variable "name" {
 variable "vlan_pool" {
   description = "Vlan pool name."
   type        = string
-
+  default = ""
   validation {
     condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.vlan_pool))
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."

--- a/modules/terraform-aci-routed-domain/variables.tf
+++ b/modules/terraform-aci-routed-domain/variables.tf
@@ -11,7 +11,7 @@ variable "name" {
 variable "vlan_pool" {
   description = "Vlan pool name."
   type        = string
-  default = ""
+  default     = ""
   validation {
     condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.vlan_pool))
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."


### PR DESCRIPTION
update to documentation based on changes here
https://wwwin-github.cisco.com/netascode/aac/pull/337