### PR TITLE
Ignore NDO annotation changes on L3Outs

### DIFF
--- a/modules/terraform-aci-l3out/main.tf
+++ b/modules/terraform-aci-l3out/main.tf
@@ -15,6 +15,10 @@ resource "aci_rest_managed" "l3extOut" {
     targetDscp    = var.target_dscp
     enforceRtctrl = join(",", concat(var.export_route_control_enforcement == true ? ["export"] : [], var.import_route_control_enforcement == true ? ["import"] : []))
   }
+
+  lifecycle {
+    ignore_changes = [annotation]
+  }
 }
 
 resource "aci_rest_managed" "ospfExtP" {
@@ -58,6 +62,10 @@ resource "aci_rest_managed" "l3extRsEctx" {
   class_name = "l3extRsEctx"
   content = {
     tnFvCtxName = var.vrf
+  }
+
+  lifecycle {
+    ignore_changes = [annotation]
   }
 }
 


### PR DESCRIPTION
There are two options to configure L3Outs with NDO:

1. The legacy option defines the L3Out and associated VRF with the remainder of the configuration applied via the APIC
2. The new option defines the entire L3Out in NDO

The second option is not yet supported in Terraform, and therefore most people will use the first option.

Each time the template containing the L3Out is deployed by NDO, the `annotation` on the `l3extOut` and `l3extRsEctx` objects is changed to `orchestrator:msc-shadow:no`.

The next time the configuration is applied to the APIC it will change the `annotation` back to whatever has been defined in the `aci` provider configuration.

This causes unnecessary ongoing changes. This PR implements a workaround to ignore `annotation` changes on these two objects. It should remain in place until the `terraform-mso-nac-ndo` module and `mso` provider support the full configuration of L3Outs in NDO.