### PR TITLE
adding support for secondary IP under floating SVI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Additional example repositories:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.15.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.6.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.3.0 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.2.5 |
 

--- a/modules/terraform-aci-l3out-interface-profile/README.md
+++ b/modules/terraform-aci-l3out-interface-profile/README.md
@@ -81,13 +81,13 @@ module "aci_l3out_interface_profile" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.15.0 |
 
 ## Inputs
 
@@ -150,6 +150,7 @@ module "aci_l3out_interface_profile" {
 | [aci_rest_managed.l3extIp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extIp_A](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extIp_B](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.l3extIp_floating](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extLIfP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extMember_A](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extMember_B](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-l3out-interface-profile/README.md
+++ b/modules/terraform-aci-l3out-interface-profile/README.md
@@ -81,13 +81,13 @@ module "aci_l3out_interface_profile" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.15.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.15.0 |
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
 
 ## Inputs
 

--- a/modules/terraform-aci-l3out-interface-profile/main.tf
+++ b/modules/terraform-aci-l3out-interface-profile/main.tf
@@ -78,6 +78,7 @@ locals {
         node_id      = int.node_id
         pod_id       = int.pod_id
         scope        = int.scope
+        ip_shared    = int.ip_shared
       }
     } if int.floating_svi == true
   ])
@@ -343,6 +344,15 @@ resource "aci_rest_managed" "l3extVirtualLIfP" {
     mtu        = each.value.mtu
     nodeDn     = "topology/pod-${each.value.pod_id}/node-${each.value.node_id}"
     encapScope = each.value.scope == "vrf" ? "ctx" : "local"
+  }
+}
+
+resource "aci_rest_managed" "l3extIp_floating" {
+  for_each   = { for item in local.floating_interfaces : item.key => item.value if item.value.ip_shared != null }
+  dn         = "${aci_rest_managed.l3extVirtualLIfP[each.key].dn}/addr-[${each.value.ip_shared}]"
+  class_name = "l3extIp"
+  content = {
+    addr = each.value.ip_shared
   }
 }
 

--- a/modules/terraform-aci-l3out-interface-profile/versions.tf
+++ b/modules/terraform-aci-l3out-interface-profile/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.15.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/modules/terraform-aci-l3out-interface-profile/versions.tf
+++ b/modules/terraform-aci-l3out-interface-profile/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.0.0"
+      version = ">= 2.15.0"
     }
   }
 }

--- a/modules/terraform-aci-l3out/README.md
+++ b/modules/terraform-aci-l3out/README.md
@@ -72,13 +72,13 @@ module "aci_l3out" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.15.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.15.0 |
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
 
 ## Inputs
 

--- a/modules/terraform-aci-l3out/versions.tf
+++ b/modules/terraform-aci-l3out/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.15.0"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.15.0"
+      version = ">= 2.6.1"
     }
     utils = {
       source  = "netascode/utils"


### PR DESCRIPTION
Added ip_shared as attribute for local.floating_interfaces and l3extIp_floating resource. Resolves #104 