### PR TITLE
Enhance action support in aci-endpoint-loop-protection module

### DIFF
--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -27,8 +27,9 @@ module "aci_endpoint_loop_protection" {
   source = "./modules/terraform-aci-endpoint-loop-protection"
 
   count                = local.modules.aci_endpoint_loop_protection == true && var.manage_fabric_policies ? 1 : 0
-  action               = try(local.fabric_policies.ep_loop_protection.action, local.defaults.apic.fabric_policies.ep_loop_protection.action)
   admin_state          = try(local.fabric_policies.ep_loop_protection.admin_state, local.defaults.apic.fabric_policies.ep_loop_protection.admin_state)
+  bd_learn_disable     = try(local.fabric_policies.ep_loop_protection.bd_learn_disable, local.fabric_policies.ep_loop_protection.action == "bd-learn-disable" ? true : false, local.defaults.apic.fabric_policies.ep_loop_protection.bd_learn_disable)
+  port_disable         = try(local.fabric_policies.ep_loop_protection.port_disable, local.fabric_policies.ep_loop_protection.action == "port-disable" ? true : false, local.defaults.apic.fabric_policies.ep_loop_protection.port_disable)
   detection_interval   = try(local.fabric_policies.ep_loop_protection.detection_interval, local.defaults.apic.fabric_policies.ep_loop_protection.detection_interval)
   detection_multiplier = try(local.fabric_policies.ep_loop_protection.detection_multiplier, local.defaults.apic.fabric_policies.ep_loop_protection.detection_multiplier)
 }

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -28,8 +28,8 @@ module "aci_endpoint_loop_protection" {
 
   count                = local.modules.aci_endpoint_loop_protection == true && var.manage_fabric_policies ? 1 : 0
   admin_state          = try(local.fabric_policies.ep_loop_protection.admin_state, local.defaults.apic.fabric_policies.ep_loop_protection.admin_state)
-  bd_learn_disable     = try(local.fabric_policies.ep_loop_protection.bd_learn_disable, local.fabric_policies.ep_loop_protection.action == "bd-learn-disable" ? true : false, local.defaults.apic.fabric_policies.ep_loop_protection.bd_learn_disable)
-  port_disable         = try(local.fabric_policies.ep_loop_protection.port_disable, local.fabric_policies.ep_loop_protection.action == "port-disable" ? true : false, local.defaults.apic.fabric_policies.ep_loop_protection.port_disable)
+  bd_learn_disable     = try(local.fabric_policies.ep_loop_protection.action == "bd-learn-disable" ? true : false, local.defaults.apic.fabric_policies.ep_loop_protection.action == "bd-learn-disable" ? true : false, local.fabric_policies.ep_loop_protection.bd_learn_disable, local.defaults.apic.fabric_policies.ep_loop_protection.bd_learn_disable)
+  port_disable         = try(local.fabric_policies.ep_loop_protection.action == "port-disable" ? true : false, local.defaults.apic.fabric_policies.ep_loop_protection.action == "port-disable" ? true : false, local.fabric_policies.ep_loop_protection.port_disable, local.defaults.apic.fabric_policies.ep_loop_protection.port_disable)
   detection_interval   = try(local.fabric_policies.ep_loop_protection.detection_interval, local.defaults.apic.fabric_policies.ep_loop_protection.detection_interval)
   detection_multiplier = try(local.fabric_policies.ep_loop_protection.detection_multiplier, local.defaults.apic.fabric_policies.ep_loop_protection.detection_multiplier)
 }

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -31,6 +31,8 @@ defaults:
         detection_interval: 60
         detection_multiplier: 4
         action: bd-learn-disable
+        bd_learn_disable: true
+        port_disable: false
       rogue_ep_control:
         admin_state: true
         detection_interval: 30

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -30,7 +30,6 @@ defaults:
         admin_state: false
         detection_interval: 60
         detection_multiplier: 4
-        action: bd-learn-disable
         bd_learn_disable: true
         port_disable: false
       rogue_ep_control:

--- a/modules/terraform-aci-endpoint-loop-protection/README.md
+++ b/modules/terraform-aci-endpoint-loop-protection/README.md
@@ -13,8 +13,9 @@ module "aci_endpoint_loop_protection" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-loop-protection"
   version = ">= 0.8.0"
 
-  action               = "bd-learn-disable"
   admin_state          = true
+  bd_learn_disable     = true
+  port_disable         = false
   detection_interval   = 90
   detection_multiplier = 10
 }
@@ -37,7 +38,8 @@ module "aci_endpoint_loop_protection" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_action"></a> [action](#input\_action) | Action. Choices: `bd-learn-disable`, `port-disable`. | `string` | `"port-disable"` | no |
+| <a name="input_bd_learn_disable"></a> [bd\_learn\_disable](#input\_bd\_learn\_disable) | Action: BD Learn Disable. | `bool` | `false` | no |
+| <a name="input_port_disable"></a> [port\_disable](#input\_port\_disable) | Action: Port Disable. | `bool` | `true` | no |
 | <a name="input_admin_state"></a> [admin\_state](#input\_admin\_state) | Admin state. | `bool` | `false` | no |
 | <a name="input_detection_interval"></a> [detection\_interval](#input\_detection\_interval) | Detection interval. Minimum value: 30. Maximum value: 300. | `number` | `60` | no |
 | <a name="input_detection_multiplier"></a> [detection\_multiplier](#input\_detection\_multiplier) | Detection multiplier. Minimum value: 1. Maximum value: 255. | `number` | `4` | no |

--- a/modules/terraform-aci-endpoint-loop-protection/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-loop-protection/examples/complete/README.md
@@ -16,8 +16,9 @@ module "aci_endpoint_loop_protection" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-loop-protection"
   version = ">= 0.8.0"
 
-  action               = "bd-learn-disable"
   admin_state          = true
+  bd_learn_disable     = true
+  port_disable         = false
   detection_interval   = 90
   detection_multiplier = 10
 }

--- a/modules/terraform-aci-endpoint-loop-protection/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-loop-protection/examples/complete/main.tf
@@ -2,8 +2,9 @@ module "aci_endpoint_loop_protection" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-loop-protection"
   version = ">= 0.8.0"
 
-  action               = "bd-learn-disable"
   admin_state          = true
+  bd_learn_disable     = true
+  port_disable         = false
   detection_interval   = 90
   detection_multiplier = 10
 }

--- a/modules/terraform-aci-endpoint-loop-protection/main.tf
+++ b/modules/terraform-aci-endpoint-loop-protection/main.tf
@@ -2,7 +2,7 @@ resource "aci_rest_managed" "epLoopProtectP" {
   dn         = "uni/infra/epLoopProtectP-default"
   class_name = "epLoopProtectP"
   content = {
-    action          = var.action
+    action          = join(",", concat(var.bd_learn_disable ? ["bd-learn-disable"] : [], var.port_disable ? ["port-disable"] : []))
     adminSt         = var.admin_state == true ? "enabled" : "disabled"
     loopDetectIntvl = var.detection_interval
     loopDetectMult  = var.detection_multiplier

--- a/modules/terraform-aci-endpoint-loop-protection/variables.tf
+++ b/modules/terraform-aci-endpoint-loop-protection/variables.tf
@@ -1,12 +1,13 @@
-variable "action" {
-  description = "Action. Choices: `bd-learn-disable`, `port-disable`."
-  type        = string
-  default     = "port-disable"
+variable "bd_learn_disable" {
+  description = "Action: BD Learn Disable."
+  type        = bool
+  default     = false
+}
 
-  validation {
-    condition     = contains(["bd-learn-disable", "port-disable"], var.action)
-    error_message = "Allowed values are `bd-learn-disable` or `port-disable`."
-  }
+variable "port_disable" {
+  description = "Action: Port Disable."
+  type        = bool
+  default     = true
 }
 
 variable "admin_state" {


### PR DESCRIPTION
To ensure backwards compatibility, the module uses the following in order of preference:
1. User specified `action`
2. User default override for `action`
3. User specified `bd_learn_disable` and `port_disable`
4. User default override for `bd_learn_disable` and `port_disable`
5. Module default for `bd_learn_disable` and `port_disable`