### PR TITLE
Enable backwards compatibility for node role

### DIFF
--- a/aci_node_policies.tf
+++ b/aci_node_policies.tf
@@ -41,7 +41,7 @@ module "aci_node_registration" {
   name           = each.value.name
   node_id        = each.value.id
   pod_id         = try(each.value.pod, local.defaults.apic.node_policies.nodes.pod)
-  role           = each.value.role
+  role           = try(each.value.set_role, local.defaults.apic.node_policies.nodes.set_role) ? each.value.role : null
   serial_number  = each.value.serial_number
   type           = try(each.value.type, "unspecified")
   remote_pool_id = try(each.value.remote_pool_id, 0)

--- a/modules/terraform-aci-node-registration/README.md
+++ b/modules/terraform-aci-node-registration/README.md
@@ -43,7 +43,7 @@ module "aci_node_registration" {
 | <a name="input_name"></a> [name](#input\_name) | Node name. | `string` | n/a | yes |
 | <a name="input_node_id"></a> [node\_id](#input\_node\_id) | Node ID. Minimum value: 1. Maximum value: 4000. | `number` | n/a | yes |
 | <a name="input_pod_id"></a> [pod\_id](#input\_pod\_id) | Pod ID. Minimum value: 1. Maximum value: 255. | `number` | `1` | no |
-| <a name="input_role"></a> [role](#input\_role) | Node role. Choices: `leaf`, `spine`. | `string` | `"unspecified"` | no |
+| <a name="input_role"></a> [role](#input\_role) | Node role. Choices: `leaf`, `spine`. | `string` | `null` | no |
 | <a name="input_serial_number"></a> [serial\_number](#input\_serial\_number) | Serial number. | `string` | n/a | yes |
 | <a name="input_type"></a> [type](#input\_type) | Node type. Choices: `remote-leaf-wan`, `virtual`, `tier-2-leaf`, `unspecified`. | `string` | `"unspecified"` | no |
 | <a name="input_remote_pool_id"></a> [remote\_pool\_id](#input\_remote\_pool\_id) | Remote Pool ID. Minimum value: 0. Maximum value: 255 | `number` | `0` | no |

--- a/modules/terraform-aci-node-registration/variables.tf
+++ b/modules/terraform-aci-node-registration/variables.tf
@@ -32,10 +32,10 @@ variable "pod_id" {
 variable "role" {
   description = "Node role. Choices: `leaf`, `spine`."
   type        = string
-  default     = "unspecified"
+  default     = null
 
   validation {
-    condition     = contains(["leaf", "spine"], var.role)
+    condition     = var.role == null ? true : contains(["leaf", "spine"], var.role)
     error_message = "Allowed values: `leaf` or `spine`."
   }
 }


### PR DESCRIPTION
This change reverts to the original behavior where the `role` attribute does not get set and therefore will remain as `unspecified`. A new `set_role` flag (default to `false`) has been defined to allow for control over this setting in certain use cases such as registering dual-role switches.