### PR TITLE
Added support for pcMember (Port Channel Member Policy) to New Interface Policy configuration

### DIFF
--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -192,7 +192,7 @@ locals {
         description                = try(interface.description, "")
         shutdown                   = try(interface.shutdown, false)
         role                       = node.role
-        port_channel_member_policy = try(interface.port_channel_member_policy, "")
+        port_channel_member_policy = try("${interface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
       } if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
@@ -212,7 +212,7 @@ module "aci_leaf_interface_configuration" {
   description                = each.value.description
   shutdown                   = each.value.shutdown
   role                       = each.value.role
-  port_channel_member_policy = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
+  port_channel_member_policy = each.value.port_channel_member_policy
 }
 
 locals {
@@ -231,7 +231,7 @@ locals {
           description                = try(subinterface.description, "")
           shutdown                   = try(subinterface.shutdown, false)
           role                       = node.role
-          port_channel_member_policy = try(subinterface.port_channel_member_policy, "")
+          port_channel_member_policy = try("${subinterface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
         }
       ] if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
@@ -252,7 +252,7 @@ module "aci_leaf_interface_configuration_sub" {
   description                = each.value.description
   shutdown                   = each.value.shutdown
   role                       = each.value.role
-  port_channel_member_policy = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
+  port_channel_member_policy = each.value.port_channel_member_policy
 
   depends_on = [
     module.aci_leaf_interface_configuration
@@ -274,7 +274,7 @@ locals {
           description                = try(interface.description, "")
           shutdown                   = try(interface.shutdown, false)
           role                       = node.role
-          port_channel_member_policy = try(interface.port_channel_member_policy, "")
+          port_channel_member_policy = try("${interface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
       }]
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
@@ -293,7 +293,7 @@ module "aci_interface_configuration_fex" {
   description                = each.value.description
   shutdown                   = each.value.shutdown
   role                       = each.value.role
-  port_channel_member_policy = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
+  port_channel_member_policy = each.value.port_channel_member_policy
 
   depends_on = [
     module.aci_leaf_interface_configuration,

--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -205,7 +205,7 @@ module "aci_leaf_interface_configuration" {
   node_id           = each.value.node_id
   module            = each.value.module
   port              = each.value.port
-  policy_group_type  = each.value.policy_group_type
+  policy_group_type = each.value.policy_group_type
   policy_group      = each.value.policy_group
   breakout          = each.value.breakout
   fex_id            = each.value.fex_id

--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -205,7 +205,7 @@ module "aci_leaf_interface_configuration" {
   node_id           = each.value.node_id
   module            = each.value.module
   port              = each.value.port
-  policy_group_typ  = each.value.policy_group_type
+  policy_group_type  = each.value.policy_group_type
   policy_group      = each.value.policy_group
   breakout          = each.value.breakout
   fex_id            = each.value.fex_id

--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -181,17 +181,17 @@ locals {
   new_leaf_interface_configuration = flatten([
     for node in local.nodes : [
       for interface in try(node.interfaces, []) : {
-        key               = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
-        node_id           = node.id
-        module            = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
-        port              = interface.port
-        policy_group_type = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
-        policy_group      = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
-        breakout          = try(interface.breakout, "none")
-        fex_id            = try(interface.fex_id, "unspecified")
-        description       = try(interface.description, "")
-        shutdown          = try(interface.shutdown, false)
-        role              = node.role
+        key                        = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
+        node_id                    = node.id
+        module                     = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
+        port                       = interface.port
+        policy_group_type          = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
+        policy_group               = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
+        breakout                   = try(interface.breakout, "none")
+        fex_id                     = try(interface.fex_id, "unspecified")
+        description                = try(interface.description, "")
+        shutdown                   = try(interface.shutdown, false)
+        role                       = node.role
         port_channel_member_policy = try(interface.port_channel_member_policy, "")
       } if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
@@ -201,17 +201,17 @@ locals {
 module "aci_leaf_interface_configuration" {
   source = "./modules/terraform-aci-interface-configuration"
 
-  for_each          = { for int in local.new_leaf_interface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
-  node_id           = each.value.node_id
-  module            = each.value.module
-  port              = each.value.port
-  policy_group_type = each.value.policy_group_type
-  policy_group      = each.value.policy_group
-  breakout          = each.value.breakout
-  fex_id            = each.value.fex_id
-  description       = each.value.description
-  shutdown          = each.value.shutdown
-  role              = each.value.role
+  for_each                   = { for int in local.new_leaf_interface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
+  node_id                    = each.value.node_id
+  module                     = each.value.module
+  port                       = each.value.port
+  policy_group_type          = each.value.policy_group_type
+  policy_group               = each.value.policy_group
+  breakout                   = each.value.breakout
+  fex_id                     = each.value.fex_id
+  description                = each.value.description
+  shutdown                   = each.value.shutdown
+  role                       = each.value.role
   port_channel_member_policy = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
 }
 
@@ -220,18 +220,18 @@ locals {
     for node in local.nodes : [
       for interface in try(node.interfaces, []) : [
         for subinterface in try(interface.sub_ports, []) : {
-          key               = format("%s/%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port, subinterface.port)
-          node_id           = node.id
-          module            = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
-          port              = interface.port
-          sub_port          = subinterface.port
-          policy_group_type = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == subinterface.policy_group][0], "access")
-          policy_group      = try("${subinterface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
-          fex_id            = try(subinterface.fex_id, "unspecified")
-          description       = try(subinterface.description, "")
-          shutdown          = try(subinterface.shutdown, false)
-          role              = node.role
-          port_channel_member_policy   = try(subinterface.port_channel_member_policy, "")
+          key                        = format("%s/%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port, subinterface.port)
+          node_id                    = node.id
+          module                     = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
+          port                       = interface.port
+          sub_port                   = subinterface.port
+          policy_group_type          = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == subinterface.policy_group][0], "access")
+          policy_group               = try("${subinterface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
+          fex_id                     = try(subinterface.fex_id, "unspecified")
+          description                = try(subinterface.description, "")
+          shutdown                   = try(subinterface.shutdown, false)
+          role                       = node.role
+          port_channel_member_policy = try(subinterface.port_channel_member_policy, "")
         }
       ] if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
@@ -241,18 +241,18 @@ locals {
 module "aci_leaf_interface_configuration_sub" {
   source = "./modules/terraform-aci-interface-configuration"
 
-  for_each          = { for int in local.new_leaf_subinterface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
-  node_id           = each.value.node_id
-  module            = each.value.module
-  port              = each.value.port
-  sub_port          = each.value.sub_port
-  policy_group_type = each.value.policy_group_type
-  policy_group      = each.value.policy_group
-  fex_id            = each.value.fex_id
-  description       = each.value.description
-  shutdown          = each.value.shutdown
-  role              = each.value.role
-  port_channel_member_policy  = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
+  for_each                   = { for int in local.new_leaf_subinterface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
+  node_id                    = each.value.node_id
+  module                     = each.value.module
+  port                       = each.value.port
+  sub_port                   = each.value.sub_port
+  policy_group_type          = each.value.policy_group_type
+  policy_group               = each.value.policy_group
+  fex_id                     = each.value.fex_id
+  description                = each.value.description
+  shutdown                   = each.value.shutdown
+  role                       = each.value.role
+  port_channel_member_policy = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_leaf_interface_configuration
@@ -264,17 +264,17 @@ locals {
     for node in local.nodes : [
       for fex in try(node.fexes, []) : [
         for interface in try(fex.interfaces, []) : {
-          key               = format("%s/%s/%s/%s", node.id, fex.id, "1", interface.port)
-          node_id           = node.id
-          module            = fex.id
-          port              = 1
-          sub_port          = interface.port
-          policy_group_type = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
-          policy_group      = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
-          description       = try(interface.description, "")
-          shutdown          = try(interface.shutdown, false)
-          role              = node.role
-          port_channel_member_policy   = try(interface.port_channel_member_policy, "")
+          key                        = format("%s/%s/%s/%s", node.id, fex.id, "1", interface.port)
+          node_id                    = node.id
+          module                     = fex.id
+          port                       = 1
+          sub_port                   = interface.port
+          policy_group_type          = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
+          policy_group               = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
+          description                = try(interface.description, "")
+          shutdown                   = try(interface.shutdown, false)
+          role                       = node.role
+          port_channel_member_policy = try(interface.port_channel_member_policy, "")
       }]
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
@@ -283,17 +283,17 @@ locals {
 module "aci_interface_configuration_fex" {
   source = "./modules/terraform-aci-interface-configuration"
 
-  for_each          = { for int in local.new_fex_interface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
-  node_id           = each.value.node_id
-  module            = each.value.module
-  port              = each.value.port
-  sub_port          = each.value.sub_port
-  policy_group_type = each.value.policy_group_type
-  policy_group      = each.value.policy_group
-  description       = each.value.description
-  shutdown          = each.value.shutdown
-  role              = each.value.role
-  port_channel_member_policy  = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
+  for_each                   = { for int in local.new_fex_interface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
+  node_id                    = each.value.node_id
+  module                     = each.value.module
+  port                       = each.value.port
+  sub_port                   = each.value.sub_port
+  policy_group_type          = each.value.policy_group_type
+  policy_group               = each.value.policy_group
+  description                = each.value.description
+  shutdown                   = each.value.shutdown
+  role                       = each.value.role
+  port_channel_member_policy = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_leaf_interface_configuration,

--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -181,17 +181,18 @@ locals {
   new_leaf_interface_configuration = flatten([
     for node in local.nodes : [
       for interface in try(node.interfaces, []) : {
-        key               = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
-        node_id           = node.id
-        module            = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
-        port              = interface.port
-        policy_group_type = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
-        policy_group      = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
-        breakout          = try(interface.breakout, "none")
-        fex_id            = try(interface.fex_id, "unspecified")
-        description       = try(interface.description, "")
-        shutdown          = try(interface.shutdown, false)
-        role              = node.role
+        key                        = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
+        node_id                    = node.id
+        module                     = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
+        port                       = interface.port
+        policy_group_type          = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
+        policy_group               = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
+        breakout                   = try(interface.breakout, "none")
+        fex_id                     = try(interface.fex_id, "unspecified")
+        description                = try(interface.description, "")
+        shutdown                   = try(interface.shutdown, false)
+        role                       = node.role
+        port_channel_member_policy = try(interface.port_channel_member_policy, "")
       } if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
@@ -200,17 +201,18 @@ locals {
 module "aci_leaf_interface_configuration" {
   source = "./modules/terraform-aci-interface-configuration"
 
-  for_each          = { for int in local.new_leaf_interface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
-  node_id           = each.value.node_id
-  module            = each.value.module
-  port              = each.value.port
-  policy_group_type = each.value.policy_group_type
-  policy_group      = each.value.policy_group
-  breakout          = each.value.breakout
-  fex_id            = each.value.fex_id
-  description       = each.value.description
-  shutdown          = each.value.shutdown
-  role              = each.value.role
+  for_each                   = { for int in local.new_leaf_interface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
+  node_id                    = each.value.node_id
+  module                     = each.value.module
+  port                       = each.value.port
+  policy_group_type          = each.value.policy_group_type
+  policy_group               = each.value.policy_group
+  breakout                   = each.value.breakout
+  fex_id                     = each.value.fex_id
+  description                = each.value.description
+  shutdown                   = each.value.shutdown
+  role                       = each.value.role
+  port_channel_member_policy = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
 }
 
 locals {

--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -272,6 +272,7 @@ locals {
           description       = try(interface.description, "")
           shutdown          = try(interface.shutdown, false)
           role              = node.role
+          port_channel_member_policy   = try(interface.port_channel_member_policy, "")
       }]
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
@@ -290,6 +291,7 @@ module "aci_interface_configuration_fex" {
   description       = each.value.description
   shutdown          = each.value.shutdown
   role              = each.value.role
+  port_channel_member_policy  = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_leaf_interface_configuration,

--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -181,17 +181,17 @@ locals {
   new_leaf_interface_configuration = flatten([
     for node in local.nodes : [
       for interface in try(node.interfaces, []) : {
-        key                        = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
-        node_id                    = node.id
-        module                     = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
-        port                       = interface.port
-        policy_group_type          = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
-        policy_group               = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
-        breakout                   = try(interface.breakout, "none")
-        fex_id                     = try(interface.fex_id, "unspecified")
-        description                = try(interface.description, "")
-        shutdown                   = try(interface.shutdown, false)
-        role                       = node.role
+        key               = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
+        node_id           = node.id
+        module            = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
+        port              = interface.port
+        policy_group_type = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
+        policy_group      = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
+        breakout          = try(interface.breakout, "none")
+        fex_id            = try(interface.fex_id, "unspecified")
+        description       = try(interface.description, "")
+        shutdown          = try(interface.shutdown, false)
+        role              = node.role
         port_channel_member_policy = try(interface.port_channel_member_policy, "")
       } if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
@@ -201,17 +201,17 @@ locals {
 module "aci_leaf_interface_configuration" {
   source = "./modules/terraform-aci-interface-configuration"
 
-  for_each                   = { for int in local.new_leaf_interface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
-  node_id                    = each.value.node_id
-  module                     = each.value.module
-  port                       = each.value.port
-  policy_group_type          = each.value.policy_group_type
-  policy_group               = each.value.policy_group
-  breakout                   = each.value.breakout
-  fex_id                     = each.value.fex_id
-  description                = each.value.description
-  shutdown                   = each.value.shutdown
-  role                       = each.value.role
+  for_each          = { for int in local.new_leaf_interface_configuration : int.key => int if local.modules.aci_interface_configuration && var.manage_interface_policies }
+  node_id           = each.value.node_id
+  module            = each.value.module
+  port              = each.value.port
+  policy_group_typ  = each.value.policy_group_type
+  policy_group      = each.value.policy_group
+  breakout          = each.value.breakout
+  fex_id            = each.value.fex_id
+  description       = each.value.description
+  shutdown          = each.value.shutdown
+  role              = each.value.role
   port_channel_member_policy = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
 }
 

--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -190,7 +190,7 @@ locals {
         breakout                   = try(interface.breakout, "none")
         fex_id                     = try(interface.fex_id, "unspecified")
         description                = try(interface.description, "")
-        shutdown                   = try(interface.shutdown, false)
+        shutdown                   = try(interface.shutdown, local.defaults.apic.interface_policies.nodes.interfaces.shutdown)
         role                       = node.role
         port_channel_member_policy = try("${interface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
       } if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
@@ -229,7 +229,7 @@ locals {
           policy_group               = try("${subinterface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
           fex_id                     = try(subinterface.fex_id, "unspecified")
           description                = try(subinterface.description, "")
-          shutdown                   = try(subinterface.shutdown, false)
+          shutdown                   = try(subinterface.shutdown, local.defaults.apic.interface_policies.nodes.interfaces.sub_ports.shutdown)
           role                       = node.role
           port_channel_member_policy = try("${subinterface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
         }
@@ -272,7 +272,7 @@ locals {
           policy_group_type          = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
           policy_group               = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
           description                = try(interface.description, "")
-          shutdown                   = try(interface.shutdown, false)
+          shutdown                   = try(interface.shutdown, local.defaults.apic.interface_policies.nodes.fexes.interfaces.shutdown.shutdown)
           role                       = node.role
           port_channel_member_policy = try("${interface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
       }]

--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -231,6 +231,7 @@ locals {
           description       = try(subinterface.description, "")
           shutdown          = try(subinterface.shutdown, false)
           role              = node.role
+          port_channel_member_policy   = try(subinterface.port_channel_member_policy, "")
         }
       ] if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
     ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
@@ -251,6 +252,7 @@ module "aci_leaf_interface_configuration_sub" {
   description       = each.value.description
   shutdown          = each.value.shutdown
   role              = each.value.role
+  port_channel_member_policy  = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_leaf_interface_configuration

--- a/modules/terraform-aci-interface-configuration/README.md
+++ b/modules/terraform-aci-interface-configuration/README.md
@@ -13,10 +13,11 @@ module "aci_interface_configuration" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-interface-configuration"
   version = ">= 0.8.0"
 
-  node_id      = 101
-  policy_group = "ACC1"
-  description  = "Port description"
-  port         = 10
+  node_id                    = 101
+  policy_group               = "ACC1"
+  description                = "Port description"
+  port                       = 10
+  port_channel_member_policy = "FAST"
 }
 ```
 

--- a/modules/terraform-aci-interface-configuration/README.md
+++ b/modules/terraform-aci-interface-configuration/README.md
@@ -48,6 +48,7 @@ module "aci_interface_configuration" {
 | <a name="input_description"></a> [description](#input\_description) | Description. | `string` | `""` | no |
 | <a name="input_role"></a> [role](#input\_role) | Node role. Allowed values: `leaf`, `spine`. | `string` | `"leaf"` | no |
 | <a name="input_shutdown"></a> [shutdown](#input\_shutdown) | Shutdown interface. | `bool` | `false` | no |
+| <a name="input_port_channel_member_policy"></a> [port\_channel\_member\_policy](#input\_port\_channel\_member\_policy) | Port Channel Member Policy. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-interface-configuration/examples/complete/README.md
+++ b/modules/terraform-aci-interface-configuration/examples/complete/README.md
@@ -16,10 +16,11 @@ module "aci_interface_configuration" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-interface-configuration"
   version = ">= 0.8.0"
 
-  node_id      = 101
-  policy_group = "ACC1"
-  description  = "Port description"
-  port         = 10
+  node_id                    = 101
+  policy_group               = "ACC1"
+  description                = "Port description"
+  port                       = 10
+  port_channel_member_policy = "FAST"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-interface-configuration/examples/complete/main.tf
+++ b/modules/terraform-aci-interface-configuration/examples/complete/main.tf
@@ -2,8 +2,9 @@ module "aci_interface_configuration" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-interface-configuration"
   version = ">= 0.8.0"
 
-  node_id      = 101
-  policy_group = "ACC1"
-  description  = "Port description"
-  port         = 10
+  node_id                    = 101
+  policy_group               = "ACC1"
+  description                = "Port description"
+  port                       = 10
+  port_channel_member_policy = "FAST"
 }

--- a/modules/terraform-aci-interface-configuration/main.tf
+++ b/modules/terraform-aci-interface-configuration/main.tf
@@ -12,5 +12,6 @@ resource "aci_rest_managed" "infraPortConfig" {
     role         = var.role
     shutdown     = var.shutdown ? "yes" : "no"
     subPort      = var.sub_port
+    pcMember     = (var.policy_group_type == "pc" || var.policy_group_type == "vpc") && var.role == "leaf" ? var.port_channel_member_policy : ""
   }
 }

--- a/modules/terraform-aci-interface-configuration/variables.tf
+++ b/modules/terraform-aci-interface-configuration/variables.tf
@@ -112,3 +112,14 @@ variable "shutdown" {
   type        = bool
   default     = false
 }
+
+variable "port_channel_member_policy" {
+  description = "Port Channel Member Policy."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.port_channel_member_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}


### PR DESCRIPTION
Updated new Interface configuration with "pcMember/port_channel_member_policy" field.
We support it on interfaces and fex interfaces for Leaves. It is not supported on sub-interfaces.