### PR TITLE
Introduce escape_html = false to banner

### DIFF
--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -21,6 +21,7 @@ module "aci_banner" {
   apic_gui_alias          = try(local.fabric_policies.banners.apic_gui_alias, "")
   apic_cli_banner         = try(local.fabric_policies.banners.apic_cli_banner, "")
   switch_cli_banner       = try(local.fabric_policies.banners.switch_cli_banner, "")
+  escape_html             = try(local.fabric_policies.banners.escape_html, local.defaults.apic.fabric_policies.banners.escape_html)
 }
 
 module "aci_endpoint_loop_protection" {

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -25,6 +25,7 @@ defaults:
         apic_gui_banner_url: ""
         apic_cli_banner: ""
         switch_cli_banner: ""
+        escape_html: true
       ep_loop_protection:
         admin_state: false
         detection_interval: 60

--- a/modules/terraform-aci-banner/README.md
+++ b/modules/terraform-aci-banner/README.md
@@ -42,6 +42,7 @@ module "aci_banner" {
 | <a name="input_apic_gui_alias"></a> [apic\_gui\_alias](#input\_apic\_gui\_alias) | APIC GUI alias. | `string` | `""` | no |
 | <a name="input_apic_cli_banner"></a> [apic\_cli\_banner](#input\_apic\_cli\_banner) | APIC CLI banner. | `string` | `""` | no |
 | <a name="input_switch_cli_banner"></a> [switch\_cli\_banner](#input\_switch\_cli\_banner) | Switch CLI banner. | `string` | `""` | no |
+| <a name="input_escape_html"></a> [escape\_html](#input\_escape\_html) | Enable escape HTML characters for banner. | `bool` | `true` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-banner/main.tf
+++ b/modules/terraform-aci-banner/main.tf
@@ -1,7 +1,7 @@
 resource "aci_rest_managed" "aaaPreLoginBanner" {
   dn         = "uni/userext/preloginbanner"
   class_name = "aaaPreLoginBanner"
-  escape_html = false
+  escape_html = var.escape_html
   content = {
     guiMessage       = var.apic_gui_banner_message != "" ? var.apic_gui_banner_message : var.apic_gui_banner_url
     isGuiMessageText = var.apic_gui_banner_message != "" ? "yes" : "no"

--- a/modules/terraform-aci-banner/main.tf
+++ b/modules/terraform-aci-banner/main.tf
@@ -1,6 +1,7 @@
 resource "aci_rest_managed" "aaaPreLoginBanner" {
   dn         = "uni/userext/preloginbanner"
   class_name = "aaaPreLoginBanner"
+  escape_html = false
   content = {
     guiMessage       = var.apic_gui_banner_message != "" ? var.apic_gui_banner_message : var.apic_gui_banner_url
     isGuiMessageText = var.apic_gui_banner_message != "" ? "yes" : "no"

--- a/modules/terraform-aci-banner/variables.tf
+++ b/modules/terraform-aci-banner/variables.tf
@@ -25,3 +25,8 @@ variable "switch_cli_banner" {
   type        = string
   default     = ""
 }
+variable "escape_html" {
+  description = "Enable escape HTML characters for banner."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Allow escape characters to be used within the aci_rest resource released in 2.15.0.

See example

```
resource "aci_rest_managed" "aaaPreLoginBanner" {
  dn          = "uni/userext/preloginbanner"
  class_name  = "aaaPreLoginBanner"
  escape_html = false
  content = {
    message = <<-EOT
<<< WARNING >>>  THE PROGRAMS AND DATA HELD ON THIS SYSTEM
ARE THE PROPERTY OF, OR LICENCED BY, XXXXXXXX. IF THE COMPANY HAS NOT
AUTHORISED YOUR ACCESS TO THIS SYSTEM YOU WILL COMMIT A CRIMINAL OFFENCE IF
YOU DO NOT IMMEDIATELY DISCONNECT. UNAUTHORISED ACCESS IS STRICTLY FORBIDDEN
AND IS A DISCIPLINARY OFFENCE.
      EOT
  }
}
```