### PR TITLE
Fix auto interface configuration

### DIFF
--- a/aci_interface_policies.tf
+++ b/aci_interface_policies.tf
@@ -20,8 +20,8 @@ locals {
   access_leaf_interface_selectors = flatten([
     for node in local.nodes : [
       for interface in try(node.interfaces, []) : {
-        key                   = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.access_policies.fex_interface_profiles.selectors.port_blocks.from_module), interface.port)
-        name                  = replace(format("%s:%s", try(interface.module, local.defaults.apic.access_policies.leaf_interface_profiles.selectors.port_blocks.from_module), interface.port), "/^(?P<mod>.+):(?P<port>.+)$/", replace(replace(try(local.access_policies.leaf_interface_selector_name, local.defaults.apic.access_policies.leaf_interface_selector_name), "\\g<mod>", "$${mod}"), "\\g<port>", "$${port}"))
+        key                   = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
+        name                  = replace(format("%s:%s", try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port), "/^(?P<mod>.+):(?P<port>.+)$/", replace(replace(try(local.access_policies.leaf_interface_selector_name, local.defaults.apic.access_policies.leaf_interface_selector_name), "\\g<mod>", "$${mod}"), "\\g<port>", "$${port}"))
         description           = try(local.apic.interface_selector_description, local.defaults.apic.interface_selector_description) ? try(interface.description, "") : ""
         interface_profile     = replace("${node.id}:${node.name}", "/^(?P<id>.+):(?P<name>.+)$/", replace(replace(try(local.access_policies.leaf_interface_profile_name, local.defaults.apic.access_policies.leaf_interface_profile_name), "\\g<id>", "$${id}"), "\\g<name>", "$${name}"))
         fex_id                = try(interface.fex_id, 0)
@@ -30,14 +30,14 @@ locals {
         policy_group_type     = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
         port_blocks = [{
           description = try(interface.description, "")
-          name        = format("%s-%s", try(interface.module, local.defaults.apic.access_policies.leaf_interface_profiles.selectors.port_blocks.from_module), interface.port)
-          from_module = try(interface.module, local.defaults.apic.access_policies.leaf_interface_profiles.selectors.port_blocks.from_module)
+          name        = format("%s-%s", try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
+          from_module = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
           from_port   = interface.port
-          to_module   = try(interface.module, local.defaults.apic.access_policies.leaf_interface_profiles.selectors.port_blocks.from_module)
+          to_module   = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
           to_port     = interface.port
         }]
       }
-    ] if(try(local.apic.auto_generate_switch_pod_profiles, local.defaults.apic.auto_generate_switch_pod_profiles) || try(local.apic.auto_generate_access_leaf_switch_interface_profiles, local.defaults.apic.auto_generate_access_leaf_switch_interface_profiles)) && node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == false
+    ] if(try(local.apic.auto_generate_switch_pod_profiles, local.defaults.apic.auto_generate_switch_pod_profiles) || try(local.apic.auto_generate_access_leaf_switch_interface_profiles, local.defaults.apic.auto_generate_access_leaf_switch_interface_profiles)) && node.role == "leaf" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == false
   ])
 }
 
@@ -64,8 +64,8 @@ locals {
     for node in local.nodes : [
       for interface in try(node.interfaces, []) : [
         for sub in try(interface.sub_ports, []) : {
-          key                   = format("%s/%s/%s/%s", node.id, try(interface.module, local.defaults.apic.access_policies.fex_interface_profiles.selectors.port_blocks.from_module), interface.port, sub.port)
-          name                  = replace(format("%s:%s:%s", try(interface.module, local.defaults.apic.access_policies.leaf_interface_profiles.selectors.port_blocks.from_module), interface.port, sub.port), "/^(?P<mod>.+):(?P<port>.+):(?P<sport>.+)$/", replace(replace(replace(try(local.access_policies.leaf_interface_selector_sub_port_name, local.defaults.apic.access_policies.leaf_interface_selector_sub_port_name), "\\g<mod>", "$${mod}"), "\\g<port>", "$${port}"), "\\g<sport>", "$${sport}"))
+          key                   = format("%s/%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port, sub.port)
+          name                  = replace(format("%s:%s:%s", try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port, sub.port), "/^(?P<mod>.+):(?P<port>.+):(?P<sport>.+)$/", replace(replace(replace(try(local.access_policies.leaf_interface_selector_sub_port_name, local.defaults.apic.access_policies.leaf_interface_selector_sub_port_name), "\\g<mod>", "$${mod}"), "\\g<port>", "$${port}"), "\\g<sport>", "$${sport}"))
           description           = try(local.apic.interface_selector_description, local.defaults.apic.interface_selector_description) ? try(sub.description, "") : ""
           interface_profile     = replace("${node.id}:${node.name}", "/^(?P<id>.+):(?P<name>.+)$/", replace(replace(try(local.access_policies.leaf_interface_profile_name, local.defaults.apic.access_policies.leaf_interface_profile_name), "\\g<id>", "$${id}"), "\\g<name>", "$${name}"))
           fex_id                = try(sub.fex_id, 0)
@@ -74,17 +74,17 @@ locals {
           policy_group_type     = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == sub.policy_group][0], "access")
           sub_port_blocks = [{
             description   = try(sub.description, "")
-            name          = format("%s-%s-%s", try(interface.module, local.defaults.apic.access_policies.leaf_interface_profiles.selectors.port_blocks.from_module), interface.port, sub.port)
-            from_module   = try(interface.module, local.defaults.apic.access_policies.leaf_interface_profiles.selectors.port_blocks.from_module)
+            name          = format("%s-%s-%s", try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port, sub.port)
+            from_module   = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
             from_port     = interface.port
-            to_module     = try(interface.module, local.defaults.apic.access_policies.leaf_interface_profiles.selectors.port_blocks.from_module)
+            to_module     = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
             to_port       = interface.port
             from_sub_port = sub.port
             to_sub_port   = sub.port
           }]
         }
       ]
-    ] if(try(local.apic.auto_generate_switch_pod_profiles, local.defaults.apic.auto_generate_switch_pod_profiles) || try(local.apic.auto_generate_access_leaf_switch_interface_profiles, local.defaults.apic.auto_generate_access_leaf_switch_interface_profiles)) && node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == false
+    ] if(try(local.apic.auto_generate_switch_pod_profiles, local.defaults.apic.auto_generate_switch_pod_profiles) || try(local.apic.auto_generate_access_leaf_switch_interface_profiles, local.defaults.apic.auto_generate_access_leaf_switch_interface_profiles)) && node.role == "leaf" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == false
   ])
 }
 
@@ -111,23 +111,23 @@ locals {
     for node in local.nodes : [
       for fex in try(node.fexes, []) : [
         for interface in try(fex.interfaces, []) : {
-          key               = format("%s/%s/%s/%s", node.id, fex.id, try(interface.module, local.defaults.apic.access_policies.fex_interface_profiles.selectors.port_blocks.from_module), interface.port)
-          name              = replace(format("%s:%s", try(interface.module, local.defaults.apic.access_policies.fex_interface_profiles.selectors.port_blocks.from_module), interface.port), "/^(?P<mod>.+):(?P<port>.+)$/", replace(replace(try(local.access_policies.fex_interface_selector_name, local.defaults.apic.access_policies.fex_interface_selector_name), "\\g<mod>", "$${mod}"), "\\g<port>", "$${port}"))
+          key               = format("%s/%s/%s/%s", node.id, fex.id, try(interface.module, local.defaults.apic.interface_policies.nodes.fexes.interfaces.module), interface.port)
+          name              = replace(format("%s:%s", try(interface.module, local.defaults.apic.interface_policies.nodes.fexes.interfaces.module), interface.port), "/^(?P<mod>.+):(?P<port>.+)$/", replace(replace(try(local.access_policies.fex_interface_selector_name, local.defaults.apic.access_policies.fex_interface_selector_name), "\\g<mod>", "$${mod}"), "\\g<port>", "$${port}"))
           description       = try(local.apic.interface_selector_description, local.defaults.apic.interface_selector_description) ? try(interface.description, "") : ""
           profile_name      = replace("${node.id}:${node.name}:${fex.id}", "/^(?P<id>.+):(?P<name>.+):(?P<fex>.+)$/", replace(replace(replace(try(local.access_policies.fex_profile_name, local.defaults.apic.access_policies.fex_profile_name), "\\g<id>", "$${id}"), "\\g<name>", "$${name}"), "\\g<fex>", "$${fex}"))
           policy_group      = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "")
           policy_group_type = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
           port_blocks = [{
             description = try(interface.description, "")
-            name        = format("%s-%s", try(interface.module, local.defaults.apic.access_policies.fex_interface_profiles.selectors.port_blocks.from_module), interface.port)
-            from_module = try(interface.module, local.defaults.apic.access_policies.fex_interface_profiles.selectors.port_blocks.from_module)
+            name        = format("%s-%s", try(interface.module, local.defaults.apic.interface_policies.nodes.fexes.interfaces.module), interface.port)
+            from_module = try(interface.module, local.defaults.apic.interface_policies.nodes.fexes.interfaces.module)
             from_port   = interface.port
-            to_module   = try(interface.module, local.defaults.apic.access_policies.fex_interface_profiles.selectors.port_blocks.from_module)
+            to_module   = try(interface.module, local.defaults.apic.interface_policies.nodes.fexes.interfaces.module)
             to_port     = interface.port
           }]
         }
       ]
-    ] if(try(local.apic.auto_generate_switch_pod_profiles, local.defaults.apic.auto_generate_switch_pod_profiles) || try(local.apic.auto_generate_access_leaf_switch_interface_profiles, local.defaults.apic.auto_generate_access_leaf_switch_interface_profiles)) && node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == false
+    ] if(try(local.apic.auto_generate_switch_pod_profiles, local.defaults.apic.auto_generate_switch_pod_profiles) || try(local.apic.auto_generate_access_leaf_switch_interface_profiles, local.defaults.apic.auto_generate_access_leaf_switch_interface_profiles)) && node.role == "leaf" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == false
   ])
 }
 
@@ -151,20 +151,20 @@ locals {
   access_spine_interface_selectors = flatten([
     for node in local.nodes : [
       for interface in try(node.interfaces, []) : {
-        key               = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.access_policies.fex_interface_profiles.selectors.port_blocks.from_module), interface.port)
-        name              = replace(format("%s:%s", try(interface.module, local.defaults.apic.access_policies.spine_interface_profiles.selectors.port_blocks.from_module), interface.port), "/^(?P<mod>.+):(?P<port>.+)$/", replace(replace(try(local.access_policies.spine_interface_selector_name, local.defaults.apic.access_policies.spine_interface_selector_name), "\\g<mod>", "$${mod}"), "\\g<port>", "$${port}"))
+        key               = format("%s/%s/%s", node.id, try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
+        name              = replace(format("%s:%s", try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port), "/^(?P<mod>.+):(?P<port>.+)$/", replace(replace(try(local.access_policies.spine_interface_selector_name, local.defaults.apic.access_policies.spine_interface_selector_name), "\\g<mod>", "$${mod}"), "\\g<port>", "$${port}"))
         interface_profile = replace("${node.id}:${node.name}", "/^(?P<id>.+):(?P<name>.+)$/", replace(replace(try(local.access_policies.spine_interface_profile_name, local.defaults.apic.access_policies.spine_interface_profile_name), "\\g<id>", "$${id}"), "\\g<name>", "$${name}"))
         policy_group      = try("${interface.policy_group}${local.defaults.apic.access_policies.spine_interface_policy_groups.name_suffix}", "")
         port_blocks = [{
-          name        = format("%s-%s", try(interface.module, local.defaults.apic.access_policies.spine_interface_profiles.selectors.port_blocks.from_module), interface.port)
+          name        = format("%s-%s", try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module), interface.port)
           description = try(interface.description, "")
-          from_module = try(interface.module, local.defaults.apic.access_policies.spine_interface_profiles.selectors.port_blocks.from_module)
+          from_module = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
           from_port   = interface.port
-          to_module   = try(interface.module, local.defaults.apic.access_policies.spine_interface_profiles.selectors.port_blocks.from_module)
+          to_module   = try(interface.module, local.defaults.apic.interface_policies.nodes.interfaces.module)
           to_port     = interface.port
         }]
       }
-    ] if(try(local.apic.auto_generate_switch_pod_profiles, local.defaults.apic.auto_generate_switch_pod_profiles) || try(local.apic.auto_generate_access_spine_switch_interface_profiles, local.defaults.apic.auto_generate_access_spine_switch_interface_profiles)) && node.role == "spine" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == false
+    ] if(try(local.apic.auto_generate_switch_pod_profiles, local.defaults.apic.auto_generate_switch_pod_profiles) || try(local.apic.auto_generate_access_spine_switch_interface_profiles, local.defaults.apic.auto_generate_access_spine_switch_interface_profiles)) && node.role == "spine" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == false
   ])
 }
 
@@ -200,7 +200,7 @@ locals {
         role                       = node.role
         port_channel_member_policy = try("${interface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
       } if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
-    ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
+    ] if node.role == "leaf" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
 }
 
@@ -240,7 +240,7 @@ locals {
           port_channel_member_policy = try("${subinterface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
         }
       ] if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
-    ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
+    ] if node.role == "leaf" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
 }
 
@@ -270,10 +270,10 @@ locals {
     for node in local.nodes : [
       for fex in try(node.fexes, []) : [
         for interface in try(fex.interfaces, []) : {
-          key                        = format("%s/%s/%s/%s", node.id, fex.id, "1", interface.port)
+          key                        = format("%s/%s/%s/%s", node.id, fex.id, try(interface.module, local.defaults.apic.interface_policies.nodes.fexes.interfaces.module), interface.port)
           node_id                    = node.id
           module                     = fex.id
-          port                       = 1
+          port                       = try(interface.module, local.defaults.apic.interface_policies.nodes.fexes.interfaces.module)
           sub_port                   = interface.port
           policy_group_type          = try([for pg in local.access_policies.leaf_interface_policy_groups : pg.type if pg.name == interface.policy_group][0], "access")
           policy_group               = try("${interface.policy_group}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}", "system-ports-default")
@@ -282,7 +282,7 @@ locals {
           role                       = node.role
           port_channel_member_policy = try("${interface.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
       }]
-    ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
+    ] if node.role == "leaf" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
 }
 
@@ -320,7 +320,7 @@ locals {
         shutdown     = try(interface.shutdown, false)
         role         = node.role
       } if !try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
-    ] if node.role == "spine" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
+    ] if node.role == "spine" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
 }
 
@@ -350,7 +350,7 @@ locals {
         shutdown     = try(interface.shutdown, false)
         role         = node.role
       } if try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
-    ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
+    ] if node.role == "leaf" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
 }
 
@@ -383,7 +383,7 @@ locals {
           role         = node.role
         }
       ] if try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
-    ] if node.role == "leaf" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
+    ] if node.role == "leaf" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
 }
 
@@ -418,7 +418,7 @@ locals {
         shutdown     = try(interface.shutdown, false)
         role         = node.role
       } if try(interface.fabric, local.defaults.apic.interface_policies.nodes.interfaces.fabric)
-    ] if node.role == "spine" && (length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id)) && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
+    ] if node.role == "spine" && try(local.apic.new_interface_configuration, local.defaults.apic.new_interface_configuration) == true
   ])
 }
 

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -756,6 +756,7 @@ defaults:
         fexes:
           interfaces:
             from_module: 1
+            module: 1
             shutdown: false
 
     tenants:


### PR DESCRIPTION
The auto interface configuration was referencing the incorrect location for the default value for `module`.

There was also a conditional check `(length(var.managed_interface_policies_nodes) == 0 || contains(var.managed_interface_policies_nodes, node.id))` which was unnecessary since it was already performed when generating the `local.nodes` variable.

