### PR TITLE
Add ability to select monitoring policies

### DIFF
--- a/aci_access_policies.tf
+++ b/aci_access_policies.tf
@@ -133,6 +133,7 @@ module "aci_access_leaf_switch_policy_group" {
   forwarding_scale_policy = try("${each.value.forwarding_scale_policy}${local.defaults.apic.access_policies.switch_policies.forwarding_scale_policies.name_suffix}", "")
   bfd_ipv4_policy         = try("${each.value.bfd_ipv4_policy}${local.defaults.apic.access_policies.switch_policies.bfd_ipv4_policies.name_suffix}", "")
   bfd_ipv6_policy         = try("${each.value.bfd_ipv6_policy}${local.defaults.apic.access_policies.switch_policies.bfd_ipv6_policies.name_suffix}", "")
+  monitoring_policy       = try("${each.value.monitoring_policy}${local.defaults.apic.access_policies.switch_policies.monitoring_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_forwarding_scale_policy,
@@ -401,7 +402,8 @@ module "aci_access_leaf_interface_policy_group" {
     name           = "${monitor.name}${local.defaults.apic.access_policies.interface_policies.netflow_monitors.name_suffix}"
     ip_filter_type = try(monitor.ip_filter_type, local.defaults.apic.access_policies.leaf_interface_policy_groups.netflow_monitor_policies.ip_filter_type)
   }]
-  aaep = try("${each.value.aaep}${local.defaults.apic.access_policies.aaeps.name_suffix}", "")
+  aaep              = try("${each.value.aaep}${local.defaults.apic.access_policies.aaeps.name_suffix}", "")
+  monitoring_policy = try("${each.value.monitoring_policy}${local.defaults.apic.access_policies.interface_policies.monitoring_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_link_level_policy,

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -321,6 +321,7 @@ module "aci_fabric_leaf_switch_policy_group" {
   name                = "${each.value.name}${local.defaults.apic.fabric_policies.leaf_switch_policy_groups.name_suffix}"
   psu_policy          = try("${each.value.psu_policy}${local.defaults.apic.fabric_policies.switch_policies.psu_policies.name_suffix}", "")
   node_control_policy = try("${each.value.node_control_policy}${local.defaults.apic.fabric_policies.switch_policies.node_control_policies.name_suffix}", "")
+  monitoring_policy   = try("${each.value.monitoring_policy}${local.defaults.apic.fabric_policies.switch_policies.monitoring_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_psu_policy,
@@ -335,6 +336,7 @@ module "aci_fabric_spine_switch_policy_group" {
   name                = "${each.value.name}${local.defaults.apic.fabric_policies.spine_switch_policy_groups.name_suffix}"
   psu_policy          = try("${each.value.psu_policy}${local.defaults.apic.fabric_policies.switch_policies.psu_policies.name_suffix}", "")
   node_control_policy = try("${each.value.node_control_policy}${local.defaults.apic.fabric_policies.switch_policies.node_control_policies.name_suffix}", "")
+  monitoring_policy   = try("${each.value.monitoring_policy}${local.defaults.apic.fabric_policies.switch_policies.monitoring_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_psu_policy,
@@ -560,6 +562,7 @@ module "aci_vmware_vmm_domain" {
     statistics        = try(vc.statistics, local.defaults.apic.fabric_policies.vmware_vmm_domains.vcenters.statistics)
     mgmt_epg_type     = try(vc.mgmt_epg, local.defaults.apic.fabric_policies.vmware_vmm_domains.vcenters.mgmt_epg)
     mgmt_epg_name     = try(vc.mgmt_epg, local.defaults.apic.fabric_policies.vmware_vmm_domains.vcenters.mgmt_epg) == "oob" ? try(local.node_policies.oob_endpoint_group, local.defaults.apic.node_policies.oob_endpoint_group) : try(local.node_policies.inb_endpoint_group, local.defaults.apic.node_policies.inb_endpoint_group)
+    monitoring_policy = try("${vc.monitoring_policy}${local.defaults.apic.fabric_policies.vmware_vmm_domains.monitoring_policies.name_suffix}", "")
   }]
   vswitch_enhanced_lags = [for vel in try(each.value.vswitch.enhanced_lags, []) : {
     name      = "${vel.name}${local.defaults.apic.fabric_policies.vmware_vmm_domains.vswitch.enhanced_lags.name_suffix}"

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -167,6 +167,8 @@ defaults:
           dom: true
         psu_policies:
           name_suffix: ""
+        monitoring_policies:
+          name_suffix: ""
       leaf_switch_policy_groups:
         name_suffix: ""
       spine_switch_policy_groups:
@@ -230,6 +232,8 @@ defaults:
           mgmt_epg: inb
           dvs_version: unmanaged
           statistics: false
+        monitoring_policies:
+          name_suffix: ""
       aaa:
         remote_user_login_policy: no-login
         default_fallback_check: false
@@ -468,6 +472,8 @@ defaults:
           slow_timer_interval: 2000
           echo_receive_interval: 50
           echo_frame_source_address: 0.0.0.0
+        monitoring_policies:
+          name_suffix: ""
       spine_switch_policy_groups:
         name_suffix: ""
       leaf_switch_policy_groups:
@@ -548,6 +554,8 @@ defaults:
         netflow_monitors:
           name_suffix: ""
         netflow_records:
+          name_suffix: ""
+        monitoring_policies:
           name_suffix: ""
       leaf_interface_policy_groups:
         name_suffix: ""
@@ -760,6 +768,8 @@ defaults:
     tenants:
       managed: true
       ndo_managed: false
+      monitoring_policies:
+        name_suffix: ""
       vrfs:
         name_suffix: ""
         ndo_managed: false
@@ -782,6 +792,8 @@ defaults:
           asm_traffic_registry_max_rate: 65535
           asm_traffic_registry_source_ip: "0.0.0.0"
         preferred_group: false
+        monitoring_policies:
+          name_suffix: ""
       bridge_domains:
         name_suffix: ""
         ndo_managed: false
@@ -808,6 +820,8 @@ defaults:
           igmp_querier: false
           nd_ra_prefix: true
           no_default_gateway: false
+        monitoring_policies:
+          name_suffix: ""
       l3outs:
         name_suffix: ""
         ndo_managed: false
@@ -1009,6 +1023,8 @@ defaults:
         name_suffix: ""
         ndo_managed: false
         managed: true
+        monitoring_policies:
+          name_suffix: ""
         endpoint_groups:
           name_suffix: ""
           ndo_managed: false
@@ -1055,6 +1071,8 @@ defaults:
               name_suffix: ""
               start_ip: 0.0.0.0
               end_ip: 0.0.0.0
+          monitoring_policies:
+            name_suffix: ""
         useg_endpoint_groups:
           name_suffix: ""
           flood_in_encap: false
@@ -1083,6 +1101,8 @@ defaults:
               name_suffix: ""
               start_ip: 0.0.0.0
               end_ip: 0.0.0.0
+          monitoring_policies:
+            name_suffix: ""
         endpoint_security_groups:
           name_suffix: ""
           shutdown: false

--- a/modules/terraform-aci-access-leaf-interface-policy-group/README.md
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/README.md
@@ -26,6 +26,7 @@ module "aci_access_leaf_interface_policy_group" {
   port_channel_policy        = "LACP"
   port_channel_member_policy = "FAST"
   aaep                       = "AAEP1"
+  monitoring_policy          = "MON1"
 }
 ```
 
@@ -61,6 +62,7 @@ module "aci_access_leaf_interface_policy_group" {
 | <a name="input_port_channel_member_policy"></a> [port\_channel\_member\_policy](#input\_port\_channel\_member\_policy) | Port channel member policy name. | `string` | `""` | no |
 | <a name="input_aaep"></a> [aaep](#input\_aaep) | Attachable access entity profile name. | `string` | `""` | no |
 | <a name="input_netflow_monitor_policies"></a> [netflow\_monitor\_policies](#input\_netflow\_monitor\_policies) | List of Netflow Monitor policies. Choices `ip_filter_type`: `ipv4, `ipv6`, `ce`, `unspecified`.` | <pre>list(object({<br>    name           = string<br>    ip_filter_type = optional(string, "ipv4")<br>  }))</pre> | `[]` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Leaf interface monitoring policy name. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -83,6 +85,7 @@ module "aci_access_leaf_interface_policy_group" {
 | [aci_rest_managed.infraRsLacpPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsLldpIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsMcpIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.infraRsMonIfInfraPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsNetflowMonitorPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsStormctrlIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsStpIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/README.md
@@ -29,6 +29,7 @@ module "aci_access_leaf_interface_policy_group" {
   port_channel_policy        = "LACP"
   port_channel_member_policy = "FAST"
   aaep                       = "AAEP1"
+  monitoring_policy          = "MON1"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/main.tf
@@ -15,4 +15,5 @@ module "aci_access_leaf_interface_policy_group" {
   port_channel_policy        = "LACP"
   port_channel_member_policy = "FAST"
   aaep                       = "AAEP1"
+  monitoring_policy          = "MON1"
 }

--- a/modules/terraform-aci-access-leaf-interface-policy-group/main.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/main.tf
@@ -117,3 +117,12 @@ resource "aci_rest_managed" "infraRsNetflowMonitorPol" {
     tnNetflowMonitorPolName = each.value.name
   }
 }
+
+resource "aci_rest_managed" "infraRsMonIfInfraPol" {
+  count      = (var.type == "access" || var.type == "vpc" || var.type == "pc") && var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.infraAccGrp.dn}/rsmonIfInfraPol"
+  class_name = "infraRsMonIfInfraPol"
+  content = {
+    tnMonInfraPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-access-leaf-interface-policy-group/variables.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/variables.tf
@@ -166,3 +166,13 @@ variable "netflow_monitor_policies" {
     error_message = "`ip_filter_type`: Allowed values: `ipv4, `ipv6`, `ce`, `unspecified`"
   }
 }
+
+variable "monitoring_policy" {
+  description = "Leaf interface monitoring policy name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-access-leaf-switch-policy-group/README.md
+++ b/modules/terraform-aci-access-leaf-switch-policy-group/README.md
@@ -17,6 +17,7 @@ module "aci_access_leaf_switch_policy_group" {
   forwarding_scale_policy = "HIGH-DUAL-STACK"
   bfd_ipv4_policy         = "BFD-IPV4-POLICY"
   bfd_ipv6_policy         = "BFD-IPV6-POLICY"
+  monitoring_policy       = "MON1"
 }
 ```
 
@@ -41,6 +42,7 @@ module "aci_access_leaf_switch_policy_group" {
 | <a name="input_forwarding_scale_policy"></a> [forwarding\_scale\_policy](#input\_forwarding\_scale\_policy) | Forwarding scale policy name. | `string` | `""` | no |
 | <a name="input_bfd_ipv4_policy"></a> [bfd\_ipv4\_policy](#input\_bfd\_ipv4\_policy) | BFD IPv4 policy name. | `string` | `""` | no |
 | <a name="input_bfd_ipv6_policy"></a> [bfd\_ipv6\_policy](#input\_bfd\_ipv6\_policy) | BFD IPv6 policy name. | `string` | `""` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Leaf Switch monitoring policy name. | `string` | `null` | no |
 
 ## Outputs
 
@@ -56,5 +58,6 @@ module "aci_access_leaf_switch_policy_group" {
 | [aci_rest_managed.infraAccNodePGrp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsBfdIpv4InstPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsBfdIpv6InstPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.infraRsMonNodeInfraPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsTopoctrlFwdScaleProfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-access-leaf-switch-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-access-leaf-switch-policy-group/examples/complete/README.md
@@ -20,6 +20,7 @@ module "aci_access_leaf_switch_policy_group" {
   forwarding_scale_policy = "HIGH-DUAL-STACK"
   bfd_ipv4_policy         = "BFD-IPV4-POLICY"
   bfd_ipv6_policy         = "BFD-IPV6-POLICY"
+  monitoring_policy       = "MON1"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-access-leaf-switch-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-access-leaf-switch-policy-group/examples/complete/main.tf
@@ -6,4 +6,5 @@ module "aci_access_leaf_switch_policy_group" {
   forwarding_scale_policy = "HIGH-DUAL-STACK"
   bfd_ipv4_policy         = "BFD-IPV4-POLICY"
   bfd_ipv6_policy         = "BFD-IPV6-POLICY"
+  monitoring_policy       = "MON1"
 }

--- a/modules/terraform-aci-access-leaf-switch-policy-group/main.tf
+++ b/modules/terraform-aci-access-leaf-switch-policy-group/main.tf
@@ -29,3 +29,12 @@ resource "aci_rest_managed" "infraRsBfdIpv6InstPol" {
     tnBfdIpv6InstPolName = var.bfd_ipv6_policy
   }
 }
+
+resource "aci_rest_managed" "infraRsMonNodeInfraPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.infraAccNodePGrp.dn}/rsmonNodeInfraPol"
+  class_name = "infraRsMonNodeInfraPol"
+  content = {
+    tnMonInfraPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-access-leaf-switch-policy-group/variables.tf
+++ b/modules/terraform-aci-access-leaf-switch-policy-group/variables.tf
@@ -40,3 +40,14 @@ variable "bfd_ipv6_policy" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "monitoring_policy" {
+  description = "Leaf Switch monitoring policy name."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`, `:`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-application-profile/README.md
+++ b/modules/terraform-aci-application-profile/README.md
@@ -13,10 +13,11 @@ module "aci_application_profile" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-application-profile"
   version = ">= 0.8.0"
 
-  tenant      = "ABC"
-  name        = "AP1"
-  alias       = "AP1-ALIAS"
-  description = "My Description"
+  tenant            = "ABC"
+  name              = "AP1"
+  alias             = "AP1-ALIAS"
+  description       = "My Description"
+  monitoring_policy = "MON1"
 }
 ```
 
@@ -42,6 +43,7 @@ module "aci_application_profile" {
 | <a name="input_annotation"></a> [annotation](#input\_annotation) | Annotation value. | `string` | `null` | no |
 | <a name="input_alias"></a> [alias](#input\_alias) | Application profile alias. | `string` | `""` | no |
 | <a name="input_description"></a> [description](#input\_description) | Application profile description. | `string` | `""` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Application profile monitoring policy name. | `string` | `""` | no |
 
 ## Outputs
 
@@ -55,4 +57,5 @@ module "aci_application_profile" {
 | Name | Type |
 |------|------|
 | [aci_rest_managed.fvAp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvRsApMonPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-application-profile/examples/complete/README.md
+++ b/modules/terraform-aci-application-profile/examples/complete/README.md
@@ -16,10 +16,11 @@ module "aci_application_profile" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-application-profile"
   version = ">= 0.8.0"
 
-  tenant      = "ABC"
-  name        = "AP1"
-  alias       = "AP1-ALIAS"
-  description = "My Description"
+  tenant            = "ABC"
+  name              = "AP1"
+  alias             = "AP1-ALIAS"
+  description       = "My Description"
+  monitoring_policy = "MON1"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-application-profile/examples/complete/main.tf
+++ b/modules/terraform-aci-application-profile/examples/complete/main.tf
@@ -2,8 +2,9 @@ module "aci_application_profile" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-application-profile"
   version = ">= 0.8.0"
 
-  tenant      = "ABC"
-  name        = "AP1"
-  alias       = "AP1-ALIAS"
-  description = "My Description"
+  tenant            = "ABC"
+  name              = "AP1"
+  alias             = "AP1-ALIAS"
+  description       = "My Description"
+  monitoring_policy = "MON1"
 }

--- a/modules/terraform-aci-application-profile/main.tf
+++ b/modules/terraform-aci-application-profile/main.tf
@@ -8,3 +8,13 @@ resource "aci_rest_managed" "fvAp" {
     descr     = var.description
   }
 }
+
+resource "aci_rest_managed" "fvRsApMonPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fvAp.dn}/rsApMonPol"
+  class_name = "fvRsApMonPol"
+
+  content = {
+    tnMonEPGPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-application-profile/variables.tf
+++ b/modules/terraform-aci-application-profile/variables.tf
@@ -50,3 +50,14 @@ variable "description" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, }`, `~`, `?`, `&`, `+`. Maximum characters: 128."
   }
 }
+
+variable "monitoring_policy" {
+  description = "Application profile monitoring policy name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-bridge-domain/README.md
+++ b/modules/terraform-aci-bridge-domain/README.md
@@ -32,6 +32,7 @@ module "aci_bridge_domain" {
   unknown_ipv6_multicast     = "opt-flood"
   vrf                        = "VRF1"
   nd_interface_policy        = "ND_INTF_POL1"
+  monitoring_policy          = "MON1"
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.1.1.1/24"
@@ -101,6 +102,7 @@ module "aci_bridge_domain" {
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets. Default value `primary_ip`: `false`. Default value `public`: `false`. Default value `shared`: `false`. Default value `igmp_querier`: `false`. Default value `nd_ra_prefix`: `true`. Default value `no_default_gateway`: `false`. Default value `virtual`: `false`. | <pre>list(object({<br>    description           = optional(string, "")<br>    ip                    = string<br>    primary_ip            = optional(bool, false)<br>    public                = optional(bool, false)<br>    shared                = optional(bool, false)<br>    igmp_querier          = optional(bool, false)<br>    nd_ra_prefix          = optional(bool, true)<br>    no_default_gateway    = optional(bool, false)<br>    virtual               = optional(bool, false)<br>    nd_ra_prefix_policy   = optional(string, "")<br>    ip_dataplane_learning = optional(bool, null)<br>    tags = optional(list(object({<br>      key   = string<br>      value = string<br>    })), [])<br>  }))</pre> | `[]` | no |
 | <a name="input_l3outs"></a> [l3outs](#input\_l3outs) | List of l3outs | `list(string)` | `[]` | no |
 | <a name="input_dhcp_labels"></a> [dhcp\_labels](#input\_dhcp\_labels) | List of DHCP labels | <pre>list(object({<br>    dhcp_relay_policy  = string<br>    dhcp_option_policy = optional(string)<br>    scope              = optional(string, "tenant")<br>  }))</pre> | `[]` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Bridge domain monitoring policy name. | `string` | `""` | no |
 
 ## Outputs
 
@@ -116,6 +118,7 @@ module "aci_bridge_domain" {
 | [aci_rest_managed.dhcpLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.dhcpRsDhcpOptionPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvBD](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvRsABDPolMonPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsBDToNdP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsBDToOut](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtx](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-bridge-domain/examples/complete/README.md
+++ b/modules/terraform-aci-bridge-domain/examples/complete/README.md
@@ -35,6 +35,7 @@ module "aci_bridge_domain" {
   unknown_ipv6_multicast     = "opt-flood"
   vrf                        = "VRF1"
   nd_interface_policy        = "ND_INTF_POL1"
+  monitoring_policy          = "MON1"
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.1.1.1/24"

--- a/modules/terraform-aci-bridge-domain/examples/complete/main.tf
+++ b/modules/terraform-aci-bridge-domain/examples/complete/main.tf
@@ -21,6 +21,7 @@ module "aci_bridge_domain" {
   unknown_ipv6_multicast     = "opt-flood"
   vrf                        = "VRF1"
   nd_interface_policy        = "ND_INTF_POL1"
+  monitoring_policy          = "MON1"
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.1.1.1/24"

--- a/modules/terraform-aci-bridge-domain/main.tf
+++ b/modules/terraform-aci-bridge-domain/main.tf
@@ -192,3 +192,12 @@ resource "aci_rest_managed" "fvRsBDToNdP" {
     tnNdIfPolName = var.nd_interface_policy
   }
 }
+
+resource "aci_rest_managed" "fvRsABDPolMonPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fvBD.dn}/rsABDPolMonPol"
+  class_name = "fvRsABDPolMonPol"
+  content = {
+    tnMonEPGPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-bridge-domain/variables.tf
+++ b/modules/terraform-aci-bridge-domain/variables.tf
@@ -297,3 +297,14 @@ variable "dhcp_labels" {
     error_message = "`dhcp_option_policy`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "monitoring_policy" {
+  description = "Bridge domain monitoring policy name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-endpoint-group/README.md
+++ b/modules/terraform-aci-endpoint-group/README.md
@@ -25,6 +25,7 @@ module "aci_endpoint_group" {
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   trust_control_policy        = "TRUST_POL"
+  monitoring_policy           = "MON1"
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["I_CON1"]
@@ -151,6 +152,7 @@ module "aci_endpoint_group" {
 | <a name="input_static_endpoints"></a> [static\_endpoints](#input\_static\_endpoints) | List of static endpoints. Format `mac`: `12:34:56:78:9A:BC`. Choices `type`: `silent-host`, `tep`, `vep`. Allowed values `node_id`, `node2_id`: `1` - `4000`. Allowed values `vlan`: `1` - `4096`. Allowed values `pod_id`: `1` - `255`. Default value `pod_id`: `1`. Allowed values `port`: `1` - `127`. Allowed values `module`: `1` - `9`. Default value `module`: `1`. | <pre>list(object({<br>    name           = optional(string, "")<br>    alias          = optional(string, "")<br>    mac            = string<br>    ip             = optional(string, "0.0.0.0")<br>    type           = string<br>    node_id        = optional(number)<br>    node2_id       = optional(number)<br>    vlan           = optional(number)<br>    pod_id         = optional(number, 1)<br>    port           = optional(number)<br>    module         = optional(number, 1)<br>    channel        = optional(string)<br>    additional_ips = optional(list(string), [])<br>  }))</pre> | `[]` | no |
 | <a name="input_l4l7_virtual_ips"></a> [l4l7\_virtual\_ips](#input\_l4l7\_virtual\_ips) | List of EPG L4/L7 Virtual IPs. | <pre>list(object({<br>    ip          = string<br>    description = optional(string, "")<br>  }))</pre> | `[]` | no |
 | <a name="input_l4l7_address_pools"></a> [l4l7\_address\_pools](#input\_l4l7\_address\_pools) | List of EPG L4/L7 Address Pools. | <pre>list(object({<br>    name            = string<br>    gateway_address = string<br>    from            = optional(string, "")<br>    to              = optional(string, "")<br>  }))</pre> | `[]` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Endpoint group monitoring policy name. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -169,6 +171,7 @@ module "aci_endpoint_group" {
 | [aci_rest_managed.fvEpAnycast](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvEpNlb](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvEpReachability](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvRsAEPgMonPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsBd](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCons](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsConsIf](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-endpoint-group/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-group/examples/complete/README.md
@@ -28,6 +28,7 @@ module "aci_endpoint_group" {
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   trust_control_policy        = "TRUST_POL"
+  monitoring_policy           = "MON1"
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["I_CON1"]

--- a/modules/terraform-aci-endpoint-group/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-group/examples/complete/main.tf
@@ -14,6 +14,7 @@ module "aci_endpoint_group" {
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   trust_control_policy        = "TRUST_POL"
+  monitoring_policy           = "MON1"
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["I_CON1"]

--- a/modules/terraform-aci-endpoint-group/main.tf
+++ b/modules/terraform-aci-endpoint-group/main.tf
@@ -498,3 +498,12 @@ resource "aci_rest_managed" "fvnsUcastAddrBlk" {
   }
 }
 
+resource "aci_rest_managed" "fvRsAEPgMonPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fvAEPg.dn}/rsAEPgMonPol"
+  class_name = "fvRsAEPgMonPol"
+
+  content = {
+    tnMonEPGPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-endpoint-group/variables.tf
+++ b/modules/terraform-aci-endpoint-group/variables.tf
@@ -675,3 +675,13 @@ variable "l4l7_address_pools" {
     error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "monitoring_policy" {
+  description = "Endpoint group monitoring policy name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-switch-policy-group/README.md
+++ b/modules/terraform-aci-fabric-leaf-switch-policy-group/README.md
@@ -16,6 +16,7 @@ module "aci_fabric_leaf_switch_policy_group" {
   name                = "LEAFS"
   psu_policy          = "PSU1"
   node_control_policy = "NC1"
+  monitoring_policy   = "MON1"
 }
 ```
 
@@ -39,6 +40,7 @@ module "aci_fabric_leaf_switch_policy_group" {
 | <a name="input_name"></a> [name](#input\_name) | Leaf switch policy group name. | `string` | n/a | yes |
 | <a name="input_psu_policy"></a> [psu\_policy](#input\_psu\_policy) | PSU policy name. | `string` | `""` | no |
 | <a name="input_node_control_policy"></a> [node\_control\_policy](#input\_node\_control\_policy) | Node control policy name. | `string` | `""` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Leaf switch monitoring policy name. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -52,6 +54,7 @@ module "aci_fabric_leaf_switch_policy_group" {
 | Name | Type |
 |------|------|
 | [aci_rest_managed.fabricLeNodePGrp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fabricRsMonInstFabricPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricRsNodeCtrl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricRsPsuInstPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-leaf-switch-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-fabric-leaf-switch-policy-group/examples/complete/README.md
@@ -19,6 +19,7 @@ module "aci_fabric_leaf_switch_policy_group" {
   name                = "LEAFS"
   psu_policy          = "PSU1"
   node_control_policy = "NC1"
+  monitoring_policy   = "MON1"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-leaf-switch-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-fabric-leaf-switch-policy-group/examples/complete/main.tf
@@ -5,4 +5,5 @@ module "aci_fabric_leaf_switch_policy_group" {
   name                = "LEAFS"
   psu_policy          = "PSU1"
   node_control_policy = "NC1"
+  monitoring_policy   = "MON1"
 }

--- a/modules/terraform-aci-fabric-leaf-switch-policy-group/main.tf
+++ b/modules/terraform-aci-fabric-leaf-switch-policy-group/main.tf
@@ -21,3 +21,12 @@ resource "aci_rest_managed" "fabricRsNodeCtrl" {
     tnFabricNodeControlName = var.node_control_policy
   }
 }
+
+resource "aci_rest_managed" "fabricRsMonInstFabricPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fabricLeNodePGrp.dn}/rsmonInstFabricPol"
+  class_name = "fabricRsMonInstFabricPol"
+  content = {
+    tnMonFabricPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-switch-policy-group/variables.tf
+++ b/modules/terraform-aci-fabric-leaf-switch-policy-group/variables.tf
@@ -29,3 +29,13 @@ variable "node_control_policy" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "monitoring_policy" {
+  description = "Leaf switch monitoring policy name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-fabric-spine-switch-policy-group/README.md
+++ b/modules/terraform-aci-fabric-spine-switch-policy-group/README.md
@@ -16,6 +16,7 @@ module "aci_fabric_spine_switch_policy_group" {
   name                = "PG1"
   psu_policy          = "PSU1"
   node_control_policy = "NC1"
+  monitoring_policy   = "MON1"
 }
 ```
 
@@ -39,6 +40,7 @@ module "aci_fabric_spine_switch_policy_group" {
 | <a name="input_name"></a> [name](#input\_name) | Spine switch policy group name. | `string` | n/a | yes |
 | <a name="input_psu_policy"></a> [psu\_policy](#input\_psu\_policy) | PSU policy name. | `string` | `""` | no |
 | <a name="input_node_control_policy"></a> [node\_control\_policy](#input\_node\_control\_policy) | Node control policy name. | `string` | `""` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Spine switch monitoring policy name. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -51,6 +53,7 @@ module "aci_fabric_spine_switch_policy_group" {
 
 | Name | Type |
 |------|------|
+| [aci_rest_managed.fabricRsMonInstFabricPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricRsNodeCtrl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricRsPsuInstPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricSpNodePGrp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-fabric-spine-switch-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-fabric-spine-switch-policy-group/examples/complete/README.md
@@ -19,6 +19,7 @@ module "aci_fabric_spine_switch_policy_group" {
   name                = "PG1"
   psu_policy          = "PSU1"
   node_control_policy = "NC1"
+  monitoring_policy   = "MON1"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-spine-switch-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-fabric-spine-switch-policy-group/examples/complete/main.tf
@@ -5,4 +5,5 @@ module "aci_fabric_spine_switch_policy_group" {
   name                = "PG1"
   psu_policy          = "PSU1"
   node_control_policy = "NC1"
+  monitoring_policy   = "MON1"
 }

--- a/modules/terraform-aci-fabric-spine-switch-policy-group/main.tf
+++ b/modules/terraform-aci-fabric-spine-switch-policy-group/main.tf
@@ -21,3 +21,12 @@ resource "aci_rest_managed" "fabricRsNodeCtrl" {
     tnFabricNodeControlName = var.node_control_policy
   }
 }
+
+resource "aci_rest_managed" "fabricRsMonInstFabricPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fabricSpNodePGrp.dn}/rsmonInstFabricPol"
+  class_name = "fabricRsMonInstFabricPol"
+  content = {
+    tnMonFabricPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-fabric-spine-switch-policy-group/variables.tf
+++ b/modules/terraform-aci-fabric-spine-switch-policy-group/variables.tf
@@ -29,3 +29,13 @@ variable "node_control_policy" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "monitoring_policy" {
+  description = "Spine switch monitoring policy name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-tenant/README.md
+++ b/modules/terraform-aci-tenant/README.md
@@ -13,9 +13,10 @@ module "aci_tenant" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-tenant"
   version = ">= 0.8.0"
 
-  name        = "ABC"
-  alias       = "ABC-ALIAS"
-  description = "My Description"
+  name              = "ABC"
+  alias             = "ABC-ALIAS"
+  description       = "My Description"
+  monitoring_policy = "MON1"
 }
 ```
 
@@ -41,6 +42,7 @@ module "aci_tenant" {
 | <a name="input_alias"></a> [alias](#input\_alias) | Tenant alias. | `string` | `""` | no |
 | <a name="input_description"></a> [description](#input\_description) | Tenant description. | `string` | `""` | no |
 | <a name="input_security_domains"></a> [security\_domains](#input\_security\_domains) | Security domains associated to tenant | `list(string)` | `[]` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Tenant monitoring policy name. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -54,5 +56,6 @@ module "aci_tenant" {
 | Name | Type |
 |------|------|
 | [aci_rest_managed.aaaDomainRef](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvRsTenantMonPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvTenant](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-tenant/examples/complete/README.md
+++ b/modules/terraform-aci-tenant/examples/complete/README.md
@@ -16,9 +16,10 @@ module "aci_tenant" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-tenant"
   version = ">= 0.8.0"
 
-  name        = "ABC"
-  alias       = "ABC-ALIAS"
-  description = "My Description"
+  name              = "ABC"
+  alias             = "ABC-ALIAS"
+  description       = "My Description"
+  monitoring_policy = "MON1"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-tenant/examples/complete/main.tf
+++ b/modules/terraform-aci-tenant/examples/complete/main.tf
@@ -2,7 +2,8 @@ module "aci_tenant" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-tenant"
   version = ">= 0.8.0"
 
-  name        = "ABC"
-  alias       = "ABC-ALIAS"
-  description = "My Description"
+  name              = "ABC"
+  alias             = "ABC-ALIAS"
+  description       = "My Description"
+  monitoring_policy = "MON1"
 }

--- a/modules/terraform-aci-tenant/main.tf
+++ b/modules/terraform-aci-tenant/main.tf
@@ -17,3 +17,13 @@ resource "aci_rest_managed" "aaaDomainRef" {
     name = each.value
   }
 }
+
+resource "aci_rest_managed" "fvRsTenantMonPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fvTenant.dn}/rsTenantMonPol"
+  class_name = "fvRsTenantMonPol"
+
+  content = {
+    tnMonEPGPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-tenant/variables.tf
+++ b/modules/terraform-aci-tenant/variables.tf
@@ -53,3 +53,13 @@ variable "security_domains" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "monitoring_policy" {
+  description = "Tenant monitoring policy name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-useg-endpoint-group/README.md
+++ b/modules/terraform-aci-useg-endpoint-group/README.md
@@ -25,6 +25,7 @@ module "aci_useg_endpoint_group" {
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   trust_control_policy        = "TRUST_POL"
+  monitoring_policy           = "MON1"
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["I_CON1"]
@@ -124,6 +125,7 @@ module "aci_useg_endpoint_group" {
 | <a name="input_ip_statements"></a> [ip\_statements](#input\_ip\_statements) | IP Statements for IP type uSeg Attributes | <pre>list(object({<br>    name           = string<br>    use_epg_subnet = bool<br>    ip             = optional(string, "")<br>  }))</pre> | `[]` | no |
 | <a name="input_mac_statements"></a> [mac\_statements](#input\_mac\_statements) | MAC Statements for MAC type uSeg Attributes | <pre>list(object({<br>    name = string<br>    mac  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_l4l7_address_pools"></a> [l4l7\_address\_pools](#input\_l4l7\_address\_pools) | List of EPG L4/L7 Address Pools. | <pre>list(object({<br>    name            = string<br>    gateway_address = string<br>    from            = optional(string, "")<br>    to              = optional(string, "")<br>  }))</pre> | `[]` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | uSeg Endpoint group monitoring policy name. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -145,6 +147,7 @@ module "aci_useg_endpoint_group" {
 | [aci_rest_managed.fvEpReachability](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvIpAttr](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvMacAttr](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvRsAEPgMonPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsBd](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCons](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsConsIf](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-useg-endpoint-group/examples/complete/README.md
+++ b/modules/terraform-aci-useg-endpoint-group/examples/complete/README.md
@@ -28,6 +28,7 @@ module "aci_useg_endpoint_group" {
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   trust_control_policy        = "TRUST_POL"
+  monitoring_policy           = "MON1"
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["I_CON1"]

--- a/modules/terraform-aci-useg-endpoint-group/examples/complete/main.tf
+++ b/modules/terraform-aci-useg-endpoint-group/examples/complete/main.tf
@@ -14,6 +14,7 @@ module "aci_useg_endpoint_group" {
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
   trust_control_policy        = "TRUST_POL"
+  monitoring_policy           = "MON1"
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["I_CON1"]

--- a/modules/terraform-aci-useg-endpoint-group/main.tf
+++ b/modules/terraform-aci-useg-endpoint-group/main.tf
@@ -298,3 +298,12 @@ resource "aci_rest_managed" "fvnsUcastAddrBlk" {
   }
 }
 
+resource "aci_rest_managed" "fvRsAEPgMonPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fvAEPg.dn}/rsAEPgMonPol"
+  class_name = "fvRsAEPgMonPol"
+
+  content = {
+    tnMonEPGPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-useg-endpoint-group/variables.tf
+++ b/modules/terraform-aci-useg-endpoint-group/variables.tf
@@ -395,3 +395,13 @@ variable "l4l7_address_pools" {
     error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "monitoring_policy" {
+  description = "uSeg Endpoint group monitoring policy name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-vmware-vmm-domain/README.md
+++ b/modules/terraform-aci-vmware-vmm-domain/README.md
@@ -42,6 +42,7 @@ module "aci_vmware_vmm_domain" {
     dvs_version       = "6.5"
     statistics        = true
     mgmt_epg_type     = "oob"
+    monitoring_policy = "MON1"
   }]
   credential_policies = [{
     name     = "CP1"
@@ -90,7 +91,7 @@ module "aci_vmware_vmm_domain" {
 | <a name="input_vswitch_mtu_policy"></a> [vswitch\_mtu\_policy](#input\_vswitch\_mtu\_policy) | vSwitch MTU policy name. | `string` | `""` | no |
 | <a name="input_vswitch_netflow_policy"></a> [vswitch\_netflow\_policy](#input\_vswitch\_netflow\_policy) | vSwitch NetFlow Exporter policy name. | `string` | `""` | no |
 | <a name="input_vswitch_enhanced_lags"></a> [vswitch\_enhanced\_lags](#input\_vswitch\_enhanced\_lags) | vSwitch enhanced lags. Allowed values for `lb_mode`: `dst-ip`, `dst-ip-l4port`, `dst-ip-vlan`, `dst-ip-l4port-vlan`, `dst-mac`, `dst-l4port`, `src-ip`, `src-ip-l4port`, `src-ip-vlan`, `src-ip-l4port-vlan`, `src-mac`, `src-l4port`, `src-dst-ip`, `src-dst-ip-l4port`, `src-dst-ip-vlan`, `src-dst-ip-l4port-vlan`, `src-dst-mac`, `src-dst-l4port`, `src-port-id` or `vlan`. Default value: `src-dst-ip`. Allowed values for `mode`: `active` or `passive`. Defautl value: `active`. Allowed range for `num_links`: 2-8. | <pre>list(object({<br>    name      = string<br>    lb_mode   = optional(string, "src-dst-ip")<br>    mode      = optional(string, "active")<br>    num_links = optional(number, 2)<br>  }))</pre> | `[]` | no |
-| <a name="input_vcenters"></a> [vcenters](#input\_vcenters) | List of vCenter hosts. Choices `dvs_version`: `unmanaged`, `5.1`, `5.5`, `6.0`, `6.5`, `6.6`, `7.0`. Default value `dvs_version`: `unmanaged`. Default value `statistics`: false. Allowed values `mgmt_epg_type`: `inb`, `oob`. Default value `mgmt_epg_type`: `inb`. | <pre>list(object({<br>    name              = string<br>    hostname_ip       = string<br>    datacenter        = string<br>    credential_policy = optional(string)<br>    dvs_version       = optional(string, "unmanaged")<br>    statistics        = optional(bool, false)<br>    mgmt_epg_type     = optional(string, "inb")<br>    mgmt_epg_name     = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_vcenters"></a> [vcenters](#input\_vcenters) | List of vCenter hosts. Choices `dvs_version`: `unmanaged`, `5.1`, `5.5`, `6.0`, `6.5`, `6.6`, `7.0`. Default value `dvs_version`: `unmanaged`. Default value `statistics`: false. Allowed values `mgmt_epg_type`: `inb`, `oob`. Default value `mgmt_epg_type`: `inb`. | <pre>list(object({<br>    name              = string<br>    hostname_ip       = string<br>    datacenter        = string<br>    credential_policy = optional(string)<br>    dvs_version       = optional(string, "unmanaged")<br>    statistics        = optional(bool, false)<br>    mgmt_epg_type     = optional(string, "inb")<br>    mgmt_epg_name     = optional(string)<br>    monitoring_policy = optional(string, "")<br>  }))</pre> | `[]` | no |
 | <a name="input_credential_policies"></a> [credential\_policies](#input\_credential\_policies) | List of vCenter credentials. | <pre>list(object({<br>    name     = string<br>    username = string<br>    password = string<br>  }))</pre> | `[]` | no |
 | <a name="input_uplinks"></a> [uplinks](#input\_uplinks) | List of vSwitch uplinks. Allowed range for `id`: 1-32. | <pre>list(object({<br>    id   = number<br>    name = string<br>  }))</pre> | `[]` | no |
 | <a name="input_security_domains"></a> [security\_domains](#input\_security\_domains) | Security domains associated to VMware VMM domain | `list(string)` | `[]` | no |
@@ -112,6 +113,7 @@ module "aci_vmware_vmm_domain" {
 | [aci_rest_managed.vmmCtrlrP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vmmDomP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vmmRsAcc](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vmmRsCtrlrPMonPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vmmRsMgmtEPg](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vmmRsVswitchExporterPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vmmRsVswitchOverrideCdpIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-vmware-vmm-domain/examples/complete/README.md
+++ b/modules/terraform-aci-vmware-vmm-domain/examples/complete/README.md
@@ -45,6 +45,7 @@ module "aci_vmware_vmm_domain" {
     dvs_version       = "6.5"
     statistics        = true
     mgmt_epg_type     = "oob"
+    monitoring_policy = "MON1"
   }]
   credential_policies = [{
     name     = "CP1"

--- a/modules/terraform-aci-vmware-vmm-domain/examples/complete/main.tf
+++ b/modules/terraform-aci-vmware-vmm-domain/examples/complete/main.tf
@@ -31,6 +31,7 @@ module "aci_vmware_vmm_domain" {
     dvs_version       = "6.5"
     statistics        = true
     mgmt_epg_type     = "oob"
+    monitoring_policy = "MON1"
   }]
   credential_policies = [{
     name     = "CP1"

--- a/modules/terraform-aci-vmware-vmm-domain/main.tf
+++ b/modules/terraform-aci-vmware-vmm-domain/main.tf
@@ -158,3 +158,12 @@ resource "aci_rest_managed" "aaaDomainRef" {
     name = each.value
   }
 }
+
+resource "aci_rest_managed" "vmmRsCtrlrPMonPol" {
+  for_each   = { for vc in var.vcenters : vc.name => vc if vc.monitoring_policy != "" }
+  dn         = "${aci_rest_managed.vmmCtrlrP[each.value.name].dn}/rsctrlrPMonPol"
+  class_name = "vmmRsCtrlrPMonPol"
+  content = {
+    tDn = "uni/infra/moninfra-${each.value.monitoring_policy}"
+  }
+}

--- a/modules/terraform-aci-vmware-vmm-domain/variables.tf
+++ b/modules/terraform-aci-vmware-vmm-domain/variables.tf
@@ -162,6 +162,7 @@ variable "vcenters" {
     statistics        = optional(bool, false)
     mgmt_epg_type     = optional(string, "inb")
     mgmt_epg_name     = optional(string)
+    monitoring_policy = optional(string, "")
   }))
   default = []
 

--- a/modules/terraform-aci-vrf/README.md
+++ b/modules/terraform-aci-vrf/README.md
@@ -21,6 +21,7 @@ module "aci_vrf" {
   enforcement_preference                 = "unenforced"
   data_plane_learning                    = false
   preferred_group                        = true
+  monitoring_policy                      = "MON1"
   transit_route_tag_policy               = "TRP1"
   bgp_timer_policy                       = "BGP1"
   bgp_ipv4_address_family_context_policy = "BGP_AF_IPV4"
@@ -175,6 +176,7 @@ module "aci_vrf" {
 | <a name="input_pim_igmp_ssm_translate_policies"></a> [pim\_igmp\_ssm\_translate\_policies](#input\_pim\_igmp\_ssm\_translate\_policies) | VRF IGMP SSM tranlate policies. | <pre>list(object({<br>    group_prefix   = string<br>    source_address = string<br>  }))</pre> | `[]` | no |
 | <a name="input_leaked_internal_prefixes"></a> [leaked\_internal\_prefixes](#input\_leaked\_internal\_prefixes) | List of leaked internal prefixes. Default value `public`: false. | <pre>list(object({<br>    prefix = string<br>    public = optional(bool, false)<br>    destinations = optional(list(object({<br>      description = optional(string, "")<br>      tenant      = string<br>      vrf         = string<br>      public      = optional(bool)<br>    })), [])<br>  }))</pre> | `[]` | no |
 | <a name="input_leaked_external_prefixes"></a> [leaked\_external\_prefixes](#input\_leaked\_external\_prefixes) | List of leaked external prefixes. | <pre>list(object({<br>    prefix             = string<br>    from_prefix_length = optional(number)<br>    to_prefix_length   = optional(number)<br>    destinations = optional(list(object({<br>      description = optional(string, "")<br>      tenant      = string<br>      vrf         = string<br>    })), [])<br>  }))</pre> | `[]` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | VRF monitoring policy name. | `string` | `""` | no |
 
 ## Outputs
 
@@ -196,6 +198,7 @@ module "aci_vrf" {
 | [aci_rest_managed.dnsLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvCtx](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsBgpCtxPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvRsCtxMonPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtxToBgpCtxAfPol_ipv4](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtxToBgpCtxAfPol_ipv6](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtxToExtRouteTagPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-vrf/examples/complete/README.md
+++ b/modules/terraform-aci-vrf/examples/complete/README.md
@@ -24,6 +24,7 @@ module "aci_vrf" {
   enforcement_preference                 = "unenforced"
   data_plane_learning                    = false
   preferred_group                        = true
+  monitoring_policy                      = "MON1"
   transit_route_tag_policy               = "TRP1"
   bgp_timer_policy                       = "BGP1"
   bgp_ipv4_address_family_context_policy = "BGP_AF_IPV4"

--- a/modules/terraform-aci-vrf/examples/complete/main.tf
+++ b/modules/terraform-aci-vrf/examples/complete/main.tf
@@ -10,6 +10,7 @@ module "aci_vrf" {
   enforcement_preference                 = "unenforced"
   data_plane_learning                    = false
   preferred_group                        = true
+  monitoring_policy                      = "MON1"
   transit_route_tag_policy               = "TRP1"
   bgp_timer_policy                       = "BGP1"
   bgp_ipv4_address_family_context_policy = "BGP_AF_IPV4"

--- a/modules/terraform-aci-vrf/main.tf
+++ b/modules/terraform-aci-vrf/main.tf
@@ -511,3 +511,13 @@ resource "aci_rest_managed" "leakTo_external" {
     descr      = each.value.description
   }
 }
+
+resource "aci_rest_managed" "fvRsCtxMonPol" {
+  count      = var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fvCtx.dn}/rsCtxMonPol"
+  class_name = "fvRsCtxMonPol"
+
+  content = {
+    tnMonEPGPolName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-vrf/variables.tf
+++ b/modules/terraform-aci-vrf/variables.tf
@@ -592,3 +592,13 @@ variable "leaked_external_prefixes" {
     error_message = "`vrf`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "monitoring_policy" {
+  description = "VRF monitoring policy name."
+  type        = string
+  default     = ""
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}


### PR DESCRIPTION
M: defaults.yaml
M: aci_fabric_policies.tf
M: aci_tenants.tf
M: aci_access_policies.tf

**Fabric Policies**
M: terraform-aci-fabric-leaf-switch-policy-group
M: terraform-aci-fabric-spine-switch-policy-group

**Access Policies**
M: terraform-aci-access-leaf-switch-policy-group
M: terraform-aci-access-leaf-interface-policy-group M: terraform-aci-vmware-vmm-domain

**Tenant Policies**
M: terraform-aci-tenant
M: terraform-aci-vrf
M: terraform-aci-bridge-domain
M: terraform-aci-application-profile
M: terraform-aci-endpoint-group
M: terraform-aci-useg-endpoint-group