### PR TITLE
Fixed contract_consumers validation

### DIFF
--- a/modules/terraform-aci-external-endpoint-group/variables.tf
+++ b/modules/terraform-aci-external-endpoint-group/variables.tf
@@ -179,7 +179,7 @@ variable "contract_consumers" {
 
   validation {
     condition = alltrue([
-      for c in var.contract_consumers : can(regex("^[a-zA-Z0-9_.l-]{0,64}$", c))
+      for c in var.contract_consumers : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", c))
     ])
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }

--- a/modules/terraform-aci-login-domain/variables.tf
+++ b/modules/terraform-aci-login-domain/variables.tf
@@ -3,8 +3,8 @@ variable "name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_]{0,64}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`. Maximum characters: 64."
   }
 }
 


### PR DESCRIPTION
The validation RegEx for contract_consumers had a lowercase l for character matching instead of colon, making contracts with colons invalid.