### PR TITLE
Feature: Add labels to contract subjects and epg/esg

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -105,6 +105,25 @@ locals {
             bgp_route_summarization_policy = try(subnet.bgp_route_summarization_policy, null) != null ? "${subnet.bgp_route_summarization_policy}${local.defaults.apic.tenants.policies.bgp_route_summarization_policies.name_suffix}" : null
           }]
         }]
+        provider_subject_labels = [for label in try(vrf.subject_labels.providers, []) : {
+          name          = "${label.name}${local.defaults.apic.tenants.vrfs.provider_subject_labels.name_suffix}"
+          tag           = try(label.tag, local.defaults.apic.tenants.vrfs.provider_subject_labels.tag)
+          is_complement = try(label.is_complement, local.defaults.apic.tenants.vrfs.provider_subject_labels.is_complement)
+        }]
+        consumer_subject_labels = [for label in try(vrf.subject_labels.consumers, []) : {
+          name          = "${label.name}${local.defaults.apic.tenants.vrfs.consumer_subject_labels.name_suffix}"
+          tag           = try(label.tag, local.defaults.apic.tenants.vrfs.consumer_subject_labels.tag)
+          is_complement = try(label.is_complement, local.defaults.apic.tenants.vrfs.consumer_subject_labels.is_complement)
+        }]
+        provider_epg_labels = [for label in try(vrf.epg_labels.providers, []) : {
+          name          = "${label.name}${local.defaults.apic.tenants.vrfs.provider_epg_labels.name_suffix}"
+          tag           = try(label.tag, local.defaults.apic.tenants.vrfs.provider_epg_labels.tag)
+          is_complement = try(label.is_complement, local.defaults.apic.tenants.vrfs.provider_epg_labels.is_complement)
+        }]
+        consumer_epg_labels = [for label in try(vrf.epg_labels.consumers, []) : {
+          name = "${label.name}${local.defaults.apic.tenants.vrfs.consumer_epg_labels.name_suffix}"
+          tag  = try(label.tag, local.defaults.apic.tenants.vrfs.consumer_epg_labels.tag)
+        }]
       }
     ]
   ])
@@ -164,6 +183,10 @@ module "aci_vrf" {
   leaked_internal_prefixes                 = each.value.leaked_internal_prefixes
   leaked_external_prefixes                 = each.value.leaked_external_prefixes
   route_summarization_policies             = each.value.route_summarization_policies
+  provider_subject_labels                  = each.value.provider_subject_labels
+  consumer_subject_labels                  = each.value.consumer_subject_labels
+  provider_epg_labels                      = each.value.provider_epg_labels
+  consumer_epg_labels                      = each.value.consumer_epg_labels
 
   depends_on = [
     module.aci_tenant,
@@ -429,6 +452,23 @@ locals {
             from            = try(ap.from, "")
             to              = try(ap.to, "")
           }]
+          provider_epg_labels = [for label in try(epg.epg_labels.providers, []) : {
+            name          = "${label.name}${local.defaults.apic.tenants.application_profiles.endpoint_groups.provider_epg_labels.name_suffix}"
+            tag           = try(label.tag, local.defaults.apic.tenants.application_profiles.endpoint_groups.provider_epg_labels.tag)
+            is_complement = try(label.is_complement, local.defaults.apic.tenants.application_profiles.endpoint_groups.provider_epg_labels.is_complement)
+          }]
+          consumer_epg_labels = [for label in try(epg.epg_labels.consumers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.endpoint_groups.consumer_epg_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.endpoint_groups.consumer_epg_labels.tag)
+          }]
+          provider_subject_labels = [for label in try(epg.subject_labels.providers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.endpoint_groups.provider_subject_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.endpoint_groups.provider_subject_labels.tag)
+          }]
+          consumer_subject_labels = [for label in try(epg.subject_labels.consumers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.endpoint_groups.consumer_subject_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.endpoint_groups.consumer_subject_labels.tag)
+          }]
         }
       ]
     ]
@@ -504,8 +544,12 @@ module "aci_endpoint_group" {
     vlan           = se.vlan
     additional_ips = se.additional_ips
   }]
-  l4l7_virtual_ips   = each.value.l4l7_virtual_ips
-  l4l7_address_pools = each.value.l4l7_address_pools
+  l4l7_virtual_ips        = each.value.l4l7_virtual_ips
+  l4l7_address_pools      = each.value.l4l7_address_pools
+  provider_epg_labels     = each.value.provider_epg_labels
+  consumer_epg_labels     = each.value.consumer_epg_labels
+  provider_subject_labels = each.value.provider_subject_labels
+  consumer_subject_labels = each.value.consumer_subject_labels
 
   depends_on = [
     module.aci_tenant,
@@ -598,6 +642,23 @@ locals {
             from            = try(ap.from, "")
             to              = try(ap.to, "")
           }]
+          provider_useg_epg_labels = [for label in try(useg_epg.useg_epg_labels.providers, []) : {
+            name          = "${label.name}${local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.provider_useg_epg_labels.name_suffix}"
+            tag           = try(label.tag, local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.provider_useg_epg_labels.tag)
+            is_complement = try(label.is_complement, local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.provider_useg_epg_labels.is_complement)
+          }]
+          consumer_useg_epg_labels = [for label in try(useg_epg.useg_epg_labels.consumers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.consumer_useg_epg_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.consumer_useg_epg_labels.tag)
+          }]
+          provider_subject_labels = [for label in try(useg_epg.subject_labels.providers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.provider_subject_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.provider_subject_labels.tag)
+          }]
+          consumer_subject_labels = [for label in try(useg_epg.subject_labels.consumers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.consumer_subject_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.consumer_subject_labels.tag)
+          }]
         }
       ]
     ]
@@ -636,7 +697,11 @@ module "aci_useg_endpoint_group" {
     pod_id  = sl.pod_id == null ? try([for node in try(local.node_policies.nodes, []) : node.pod if node.id == sl.node_id][0], local.defaults.apic.node_policies.nodes.pod) : sl.pod_id
     node_id = sl.node_id
   }]
-  l4l7_address_pools = each.value.l4l7_address_pools
+  l4l7_address_pools       = each.value.l4l7_address_pools
+  provider_useg_epg_labels = each.value.provider_useg_epg_labels
+  consumer_useg_epg_labels = each.value.consumer_useg_epg_labels
+  provider_subject_labels  = each.value.provider_subject_labels
+  consumer_subject_labels  = each.value.consumer_subject_labels
 
   depends_on = [
     module.aci_tenant,
@@ -688,6 +753,23 @@ locals {
             value       = sel.value
             description = try(sel.description, "")
           }]
+          provider_esg_labels = [for label in try(esg.esg_labels.providers, []) : {
+            name          = "${label.name}${local.defaults.apic.tenants.application_profiles.endpoint_security_groups.provider_esg_labels.name_suffix}"
+            tag           = try(label.tag, local.defaults.apic.tenants.application_profiles.endpoint_security_groups.provider_esg_labels.tag)
+            is_complement = try(label.is_complement, local.defaults.apic.tenants.application_profiles.endpoint_security_groups.provider_esg_labels.is_complement)
+          }]
+          consumer_esg_labels = [for label in try(esg.esg_labels.consumers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.endpoint_security_groups.consumer_esg_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.endpoint_security_groups.consumer_esg_labels.tag)
+          }]
+          provider_subject_labels = [for label in try(esg.subject_labels.providers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.endpoint_security_groups.provider_subject_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.endpoint_security_groups.provider_subject_labels.tag)
+          }]
+          consumer_subject_labels = [for label in try(esg.subject_labels.consumers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.application_profiles.endpoint_security_groups.consumer_subject_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.application_profiles.endpoint_security_groups.consumer_subject_labels.tag)
+          }]
         }
       ]
     ]
@@ -714,6 +796,10 @@ module "aci_endpoint_security_group" {
   tag_selectors               = each.value.tag_selectors
   epg_selectors               = each.value.epg_selectors
   ip_subnet_selectors         = each.value.ip_subnet_selectors
+  provider_esg_labels         = each.value.provider_esg_labels
+  consumer_esg_labels         = each.value.consumer_esg_labels
+  provider_subject_labels     = each.value.provider_subject_labels
+  consumer_subject_labels     = each.value.consumer_subject_labels
 
   depends_on = [
     module.aci_tenant,
@@ -1487,6 +1573,23 @@ locals {
               direction = try(rcp.direction, local.defaults.apic.tenants.l3outs.external_endpoint_groups.subnets.route_control_profiles.direction)
             }]
           }]
+          provider_epg_labels = [for label in try(epg.epg_labels.providers, []) : {
+            name          = "${label.name}${local.defaults.apic.tenants.l3outs.external_endpoint_groups.provider_epg_labels.name_suffix}"
+            tag           = try(label.tag, local.defaults.apic.tenants.l3outs.external_endpoint_groups.provider_epg_labels.tag)
+            is_complement = try(label.is_complement, local.defaults.apic.tenants.l3outs.external_endpoint_groups.provider_epg_labels.is_complement)
+          }]
+          consumer_epg_labels = [for label in try(epg.epg_labels.consumers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.l3outs.external_endpoint_groups.consumer_epg_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.l3outs.external_endpoint_groups.consumer_epg_labels.tag)
+          }]
+          provider_subject_labels = [for label in try(epg.subject_labels.providers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.l3outs.external_endpoint_groups.provider_subject_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.l3outs.external_endpoint_groups.provider_subject_labels.tag)
+          }]
+          consumer_subject_labels = [for label in try(epg.subject_labels.consumers, []) : {
+            name = "${label.name}${local.defaults.apic.tenants.l3outs.external_endpoint_groups.consumer_subject_labels.name_suffix}"
+            tag  = try(label.tag, local.defaults.apic.tenants.l3outs.external_endpoint_groups.consumer_subject_labels.tag)
+          }]
         }
       ]
     ]
@@ -1511,6 +1614,10 @@ module "aci_external_endpoint_group" {
   contract_imported_consumers = each.value.contract_imported_consumers
   route_control_profiles      = each.value.route_control_profiles
   subnets                     = each.value.subnets
+  consumer_epg_labels         = each.value.consumer_epg_labels
+  provider_epg_labels         = each.value.provider_epg_labels
+  consumer_subject_labels     = each.value.consumer_subject_labels
+  provider_subject_labels     = each.value.provider_subject_labels
 
   depends_on = [
     module.aci_tenant,
@@ -1809,18 +1916,30 @@ locals {
         qos_class   = try(contract.qos_class, local.defaults.apic.tenants.contracts.qos_class)
         target_dscp = try(contract.target_dscp, local.defaults.apic.tenants.contracts.target_dscp)
         subjects = [for subject in try(contract.subjects, []) : {
-          name          = "${subject.name}${local.defaults.apic.tenants.contracts.subjects.name_suffix}"
-          alias         = try(subject.alias, "")
-          description   = try(subject.description, "")
-          service_graph = try("${subject.service_graph}${local.defaults.apic.tenants.services.service_graph_templates.name_suffix}", null)
-          qos_class     = try(subject.qos_class, local.defaults.apic.tenants.contracts.subjects.qos_class)
-          target_dscp   = try(subject.target_dscp, local.defaults.apic.tenants.contracts.subjects.target_dscp)
+          name                 = "${subject.name}${local.defaults.apic.tenants.contracts.subjects.name_suffix}"
+          alias                = try(subject.alias, "")
+          description          = try(subject.description, "")
+          service_graph        = try("${subject.service_graph}${local.defaults.apic.tenants.services.service_graph_templates.name_suffix}", null)
+          qos_class            = try(subject.qos_class, local.defaults.apic.tenants.contracts.subjects.qos_class)
+          target_dscp          = try(subject.target_dscp, local.defaults.apic.tenants.contracts.subjects.target_dscp)
+          provider_label_match = try(subject.provider_label_match, local.defaults.apic.tenants.contracts.subjects.provider_label_match)
+          consumer_label_match = try(subject.consumer_label_match, local.defaults.apic.tenants.contracts.subjects.consumer_label_match)
           filters = [for filter in try(subject.filters, []) : {
             filter   = "${filter.filter}${local.defaults.apic.tenants.filters.name_suffix}"
             action   = try(filter.action, local.defaults.apic.tenants.contracts.subjects.filters.action)
             priority = try(filter.priority, local.defaults.apic.tenants.contracts.subjects.filters.priority)
             log      = try(filter.log, local.defaults.apic.tenants.contracts.subjects.filters.log)
             no_stats = try(filter.no_stats, local.defaults.apic.tenants.contracts.subjects.filters.no_stats)
+          }]
+          provider_labels = [for label in try(subject.labels.providers, []) : {
+            name          = "${label.name}${local.defaults.apic.tenants.contracts.subjects.provider_labels.name_suffix}"
+            tag           = try(label.tag, local.defaults.apic.tenants.contracts.subjects.provider_labels.tag)
+            is_complement = try(label.is_complement, local.defaults.apic.tenants.contracts.subjects.provider_labels.is_complement)
+          }]
+          consumer_labels = [for label in try(subject.labels.consumers, []) : {
+            name          = "${label.name}${local.defaults.apic.tenants.contracts.subjects.consumer_labels.name_suffix}"
+            tag           = try(label.tag, local.defaults.apic.tenants.contracts.subjects.consumer_labels.tag)
+            is_complement = try(label.is_complement, local.defaults.apic.tenants.contracts.subjects.consumer_labels.is_complement)
           }]
         }]
       }

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -806,6 +806,22 @@ defaults:
           name_suffix: ""
           nodes:
             pod: 1
+        provider_subject_labels:
+          name_suffix: ""
+          tag: black
+          is_complement: false
+        consumer_subject_labels:
+          name_suffix: ""
+          tag: black
+          is_complement: false
+        provider_epg_labels:
+          name_suffix: ""
+          tag: black
+          is_complement: false
+        consumer_epg_labels:
+          name_suffix: ""
+          tag: black
+          is_complement: false
       bridge_domains:
         name_suffix: ""
         ndo_managed: false
@@ -1010,6 +1026,19 @@ defaults:
             route_control_profiles:
               name_suffix: ""
               direction: import
+          consumer_subject_labels:
+            name_suffix: ""
+            tag: black
+          provider_subject_labels:
+            name_suffix: ""
+            tag: black
+          consumer_epg_labels:
+            name_suffix: ""
+            tag: black
+          provider_epg_labels:
+            name_suffix: ""
+            tag: black
+            is_complement: false  
         import_route_map:
           type: global
           contexts:
@@ -1080,6 +1109,15 @@ defaults:
               name_suffix: ""
               start_ip: 0.0.0.0
               end_ip: 0.0.0.0
+          consumer_subject_labels:
+            name_suffix: ""
+          provider_subject_labels:
+            name_suffix: ""
+          consumer_epg_labels:
+            name_suffix: ""
+          provider_epg_labels:
+            name_suffix: ""
+            is_complement: false
         useg_endpoint_groups:
           name_suffix: ""
           flood_in_encap: false
@@ -1108,6 +1146,19 @@ defaults:
               name_suffix: ""
               start_ip: 0.0.0.0
               end_ip: 0.0.0.0
+          consumer_subject_labels:
+            name_suffix: ""
+            tag: black
+          provider_subject_labels:
+            name_suffix: ""
+            tag: black
+          provider_useg_epg_labels:
+            name_suffix: ""
+            tag: black
+            is_complement: false
+          consumer_useg_epg_labels:
+            name_suffix: ""
+            tag: black
         endpoint_security_groups:
           name_suffix: ""
           shutdown: false
@@ -1115,6 +1166,19 @@ defaults:
           preferred_group: false
           tag_selectors:
             operator: equals
+          consumer_subject_labels:
+            name_suffix: ""
+            tag: black
+          provider_subject_labels:
+            name_suffix: ""
+            tag: black
+          provider_esg_labels:
+            name_suffix: ""
+            tag: black
+            is_complement: false
+          consumer_esg_labels:
+            name_suffix: ""
+            tag: black
       inb_endpoint_groups:
         name_suffix: ""
       oob_endpoint_groups:
@@ -1172,6 +1236,14 @@ defaults:
             priority: default
             log: false
             no_stats: false
+          consumer_label_match: AtleastOne
+          provider_label_match: AtleastOne
+          provider_labels:
+            name_suffix: ""
+            is_complement: false
+          consumer_labels:
+            name_suffix: ""
+            is_complement: false
       imported_contracts:
         name_suffix: ""
       oob_contracts:

--- a/modules/terraform-aci-contract/README.md
+++ b/modules/terraform-aci-contract/README.md
@@ -34,6 +34,18 @@ module "aci_contract" {
       log      = true
       no_stats = true
     }]
+    consumer_label_match = "AtleastOne"
+    provider_label_match = "AtleastOne"
+    consumer_labels = [{
+      name          = "Label01"
+      tag           = "blue"
+      is_complement = false
+    }]
+    provider_labels = [{
+      name          = "Label02"
+      tag           = "green"
+      is_complement = false
+    }]
   }]
 }
 ```
@@ -62,7 +74,7 @@ module "aci_contract" {
 | <a name="input_scope"></a> [scope](#input\_scope) | Contract scope. Choices: `application-profile`, `tenant`, `context`, `global`. | `string` | `"context"` | no |
 | <a name="input_qos_class"></a> [qos\_class](#input\_qos\_class) | Contract QoS Class. Choices: `unspecified`, `level1`, `level2`, `level3`, `level4`, `level5`, `level6`. | `string` | `"unspecified"` | no |
 | <a name="input_target_dscp"></a> [target\_dscp](#input\_target\_dscp) | Contract Target DSCP. Valid values are `unspecified`, `CS0`, `CS1`, `AF11`, `AF12`, `AF13`, `CS2`, `AF21`, `AF22`, `AF23`, `CS4`, `AF41`, `AF42`, `AF43`, `CS5`, `VA`, `EF`, `CS6`, `CS7` or a number between 0 and 63. | `string` | `"unspecified"` | no |
-| <a name="input_subjects"></a> [subjects](#input\_subjects) | List of contract subjects. Choices `action`: `permit`, `deny`. Default value `action`: `permit`. Choices `priority`: `default`, `level1`, `level2`, `level3`. Default value `priority`: `default`. Default value `log`: `false`. Default value `no_stats`: `false`. Choices `qos_class`: `unspecified`, `level1`, `level2`, `level3`, `level4`, `level5` or`level6`. Default value `qos_class`: `unspecified`. Choices `dscp_target` : `unspecified`, `CS0`, `CS1`, `AF11`, `AF12`, `AF13`, `CS2`, `AF21`, `AF22`, `AF23`, `CS4`, `AF41`, `AF42`, `AF43`, `CS5`, `VA`, `EF`, `CS6` `CS7` or a number between 0 and 63. Default value `dscp_target`: `unspecified` | <pre>list(object({<br>    name          = string<br>    alias         = optional(string, "")<br>    description   = optional(string, "")<br>    service_graph = optional(string)<br>    qos_class     = optional(string, "unspecified")<br>    target_dscp   = optional(string, "unspecified")<br>    filters = optional(list(object({<br>      filter   = string<br>      action   = optional(string, "permit")<br>      priority = optional(string, "default")<br>      log      = optional(bool, false)<br>      no_stats = optional(bool, false)<br>    })), [])<br>  }))</pre> | `[]` | no |
+| <a name="input_subjects"></a> [subjects](#input\_subjects) | List of contract subjects. Choices `action`: `permit`, `deny`. Default value `action`: `permit`. Choices `priority`: `default`, `level1`, `level2`, `level3`. Default value `priority`: `default`. Default value `log`: `false`. Default value `no_stats`: `false`. Choices `qos_class`: `unspecified`, `level1`, `level2`, `level3`, `level4`, `level5` or`level6`. Default value `qos_class`: `unspecified`. Choices `dscp_target` : `unspecified`, `CS0`, `CS1`, `AF11`, `AF12`, `AF13`, `CS2`, `AF21`, `AF22`, `AF23`, `CS4`, `AF41`, `AF42`, `AF43`, `CS5`, `VA`, `EF`, `CS6` `CS7` or a number between 0 and 63. Default value `dscp_target`: `unspecified` | <pre>list(object({<br>    name          = string<br>    alias         = optional(string, "")<br>    description   = optional(string, "")<br>    service_graph = optional(string)<br>    qos_class     = optional(string, "unspecified")<br>    target_dscp   = optional(string, "unspecified")<br>    filters = optional(list(object({<br>      filter   = string<br>      action   = optional(string, "permit")<br>      priority = optional(string, "default")<br>      log      = optional(bool, false)<br>      no_stats = optional(bool, false)<br>    })), [])<br>    consumer_label_match = optional(string, "AtleastOne")<br>    provider_label_match = optional(string, "AtleastOne")<br>    consumer_labels = optional(list(object({<br>      name          = string<br>      tag           = string<br>      is_complement = optional(bool, false)<br>    })))<br>    provider_labels = optional(list(object({<br>      name          = string<br>      tag           = string<br>      is_complement = optional(bool, false)<br>    })))<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 
@@ -76,6 +88,8 @@ module "aci_contract" {
 | Name | Type |
 |------|------|
 | [aci_rest_managed.vzBrCP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vzRsSubjFiltAtt](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vzRsSubjGraphAtt](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vzSubj](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-contract/examples/complete/README.md
+++ b/modules/terraform-aci-contract/examples/complete/README.md
@@ -37,6 +37,18 @@ module "aci_contract" {
       log      = true
       no_stats = true
     }]
+    consumer_label_match = "AtleastOne"
+    provider_label_match = "AtleastOne"
+    consumer_labels = [{
+      name          = "Label01"
+      tag           = "blue"
+      is_complement = false
+    }]
+    provider_labels = [{
+      name          = "Label02"
+      tag           = "green"
+      is_complement = false
+    }]
   }]
 }
 ```

--- a/modules/terraform-aci-contract/examples/complete/main.tf
+++ b/modules/terraform-aci-contract/examples/complete/main.tf
@@ -23,5 +23,17 @@ module "aci_contract" {
       log      = true
       no_stats = true
     }]
+    consumer_label_match = "AtleastOne"
+    provider_label_match = "AtleastOne"
+    consumer_labels = [{
+      name          = "Label01"
+      tag           = "blue"
+      is_complement = false
+    }]
+    provider_labels = [{
+      name          = "Label02"
+      tag           = "green"
+      is_complement = false
+    }]
   }]
 }

--- a/modules/terraform-aci-contract/variables.tf
+++ b/modules/terraform-aci-contract/variables.tf
@@ -90,6 +90,18 @@ variable "subjects" {
       log      = optional(bool, false)
       no_stats = optional(bool, false)
     })), [])
+    consumer_label_match = optional(string, "AtleastOne")
+    provider_label_match = optional(string, "AtleastOne")
+    consumer_labels = optional(list(object({
+      name          = string
+      tag           = string
+      is_complement = optional(bool, false)
+    })))
+    provider_labels = optional(list(object({
+      name          = string
+      tag           = string
+      is_complement = optional(bool, false)
+    })))
   }))
   default = []
 
@@ -154,5 +166,47 @@ variable "subjects" {
       for s in var.subjects : [for f in coalesce(s.filters, []) : f.priority == null || try(contains(["default", "level1", "level2", "level3"], f.priority), false)]
     ]))
     error_message = "`priority`: Allowed values are `default`, `level1`, `level2` or `level3`."
+  }
+
+  validation {
+    condition = alltrue([
+      for s in var.subjects : try(contains(["All", "AtleastOne", "AtmostOne", "None"], s.provider_label_match), false)
+    ])
+    error_message = "`provider_label_match`: Allowed values are `All`, `AtleastOne`, `AtmostOne`, `None`."
+  }
+
+  validation {
+    condition = alltrue([
+      for s in var.subjects : try(contains(["All", "AtleastOne", "AtmostOne", "None"], s.consumer_label_match), false)
+    ])
+    error_message = "`consumer_label_match`: Allowed values are `All`, `AtleastOne`, `AtmostOne`, `None`."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for s in var.subjects : [for l in coalesce(s.consumer_labels, []) : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", l.name))]
+    ]))
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for s in var.subjects : [for l in coalesce(s.consumer_labels, []) : try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], l.tag), false)]
+    ]))
+    error_message = "`tag`: Allowed values: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for s in var.subjects : [for l in coalesce(s.provider_labels, []) : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", l.name))]
+    ]))
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for s in var.subjects : [for l in coalesce(s.provider_labels, []) : try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], l.tag), false)]
+    ]))
+    error_message = "`tag`: Allowed values: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
   }
 }

--- a/modules/terraform-aci-endpoint-group/README.md
+++ b/modules/terraform-aci-endpoint-group/README.md
@@ -103,6 +103,22 @@ module "aci_endpoint_group" {
     from            = "1.1.1.10"
     to              = "1.1.1.100"
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }
 ```
 
@@ -152,6 +168,10 @@ module "aci_endpoint_group" {
 | <a name="input_l4l7_virtual_ips"></a> [l4l7\_virtual\_ips](#input\_l4l7\_virtual\_ips) | List of EPG L4/L7 Virtual IPs. | <pre>list(object({<br>    ip          = string<br>    description = optional(string, "")<br>  }))</pre> | `[]` | no |
 | <a name="input_l4l7_address_pools"></a> [l4l7\_address\_pools](#input\_l4l7\_address\_pools) | List of EPG L4/L7 Address Pools. | <pre>list(object({<br>    name            = string<br>    gateway_address = string<br>    from            = optional(string, "")<br>    to              = optional(string, "")<br>  }))</pre> | `[]` | no |
 | <a name="input_bulk_static_ports"></a> [bulk\_static\_ports](#input\_bulk\_static\_ports) | Use bulk resource to configure static ports. | `bool` | `false` | no |
+| <a name="input_provider_subject_labels"></a> [provider\_subject\_labels](#input\_provider\_subject\_labels) | List of Provided subject labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_subject_labels"></a> [consumer\_subject\_labels](#input\_consumer\_subject\_labels) | List of Consumed subject labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_provider_epg_labels"></a> [provider\_epg\_labels](#input\_provider\_epg\_labels) | List of Provided EPG labels. | <pre>list(object({<br>    name          = string<br>    tag           = string<br>    is_complement = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_epg_labels"></a> [consumer\_epg\_labels](#input\_consumer\_epg\_labels) | List of Consumed EPG labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 
@@ -205,4 +225,8 @@ module "aci_endpoint_group" {
 | [aci_rest_managed.tagInst](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vmmSecP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAddrInst](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-endpoint-group/README.md
+++ b/modules/terraform-aci-endpoint-group/README.md
@@ -112,8 +112,9 @@ module "aci_endpoint_group" {
     tag  = "black"
   }]
   consumer_epg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   provider_epg_labels = [{
     name = "Label01"

--- a/modules/terraform-aci-endpoint-group/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-group/examples/complete/README.md
@@ -115,8 +115,9 @@ module "aci_endpoint_group" {
     tag  = "black"
   }]
   consumer_epg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   provider_epg_labels = [{
     name = "Label01"

--- a/modules/terraform-aci-endpoint-group/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-group/examples/complete/README.md
@@ -106,6 +106,22 @@ module "aci_endpoint_group" {
     from            = "1.1.1.10"
     to              = "1.1.1.100"
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-endpoint-group/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-group/examples/complete/main.tf
@@ -101,8 +101,9 @@ module "aci_endpoint_group" {
     tag  = "black"
   }]
   consumer_epg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   provider_epg_labels = [{
     name = "Label01"

--- a/modules/terraform-aci-endpoint-group/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-group/examples/complete/main.tf
@@ -92,4 +92,20 @@ module "aci_endpoint_group" {
     from            = "1.1.1.10"
     to              = "1.1.1.100"
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }

--- a/modules/terraform-aci-endpoint-group/main.tf
+++ b/modules/terraform-aci-endpoint-group/main.tf
@@ -588,3 +588,43 @@ resource "aci_rest_managed" "fvnsUcastAddrBlk" {
   }
 }
 
+resource "aci_rest_managed" "vzProvLbl" {
+  for_each   = { for label in var.provider_epg_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/provlbl-${each.value.name}"
+  class_name = "vzProvLbl"
+  content = {
+    name         = each.value.name
+    tag          = each.value.tag
+    isComplement = each.value.is_complement == true ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vzConsLbl" {
+  for_each   = { for label in var.consumer_epg_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/conslbl-${each.value.name}"
+  class_name = "vzConsLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzProvSubjLbl" {
+  for_each   = { for label in var.provider_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/provsubjlbl-${each.value.name}"
+  class_name = "vzProvSubjLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzConsSubjLbl" {
+  for_each   = { for label in var.consumer_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/conssubjlbl-${each.value.name}"
+  class_name = "vzConsSubjLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}

--- a/modules/terraform-aci-endpoint-group/variables.tf
+++ b/modules/terraform-aci-endpoint-group/variables.tf
@@ -681,3 +681,96 @@ variable "bulk_static_ports" {
   type        = bool
   default     = false
 }
+
+variable "provider_subject_labels" {
+  description = "List of Provided subject labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_subject_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "consumer_subject_labels" {
+  description = "List of Consumed subject labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_subject_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "provider_epg_labels" {
+  description = "List of Provided EPG labels."
+  type = list(object({
+    name          = string
+    tag           = string
+    is_complement = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_epg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_epg_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "consumer_epg_labels" {
+  description = "List of Consumed EPG labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_epg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_epg_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}

--- a/modules/terraform-aci-endpoint-security-group/README.md
+++ b/modules/terraform-aci-endpoint-security-group/README.md
@@ -88,8 +88,9 @@ module "aci_endpoint_security_group" {
     tag  = "black"
   }]
   provider_esg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
 }
 ```

--- a/modules/terraform-aci-endpoint-security-group/README.md
+++ b/modules/terraform-aci-endpoint-security-group/README.md
@@ -75,6 +75,22 @@ module "aci_endpoint_security_group" {
       description = "foo"
     }
   ]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_esg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_esg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }
 ```
 
@@ -111,6 +127,10 @@ module "aci_endpoint_security_group" {
 | <a name="input_tag_selectors"></a> [tag\_selectors](#input\_tag\_selectors) | List of tag selectors.  Choices `operator`: `contains`, `equals`, `regex`. Default value `operator`: `equals`. | <pre>list(object({<br>    key         = string<br>    operator    = optional(string, "equals")<br>    value       = string<br>    description = optional(string, "")<br>  }))</pre> | `[]` | no |
 | <a name="input_epg_selectors"></a> [epg\_selectors](#input\_epg\_selectors) | List of EPG selectors. | <pre>list(object({<br>    tenant              = string<br>    application_profile = string<br>    endpoint_group      = string<br>    description         = optional(string, "")<br>  }))</pre> | `[]` | no |
 | <a name="input_ip_subnet_selectors"></a> [ip\_subnet\_selectors](#input\_ip\_subnet\_selectors) | List of IP subnet selectors. | <pre>list(object({<br>    value       = string<br>    description = optional(string, "")<br>  }))</pre> | `[]` | no |
+| <a name="input_provider_subject_labels"></a> [provider\_subject\_labels](#input\_provider\_subject\_labels) | List of Provided subject labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_subject_labels"></a> [consumer\_subject\_labels](#input\_consumer\_subject\_labels) | List of Consumed subject labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_provider_esg_labels"></a> [provider\_esg\_labels](#input\_provider\_esg\_labels) | List of Provided EPG labels. | <pre>list(object({<br>    name          = string<br>    tag           = string<br>    is_complement = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_esg_labels"></a> [consumer\_esg\_labels](#input\_consumer\_esg\_labels) | List of Consumed EPG labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 
@@ -136,4 +156,8 @@ module "aci_endpoint_security_group" {
 | [aci_rest_managed.fvRsScope](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsSecInherited](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvTagSelector](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-endpoint-security-group/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-security-group/examples/complete/README.md
@@ -91,8 +91,9 @@ module "aci_endpoint_security_group" {
     tag  = "black"
   }]
   provider_esg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
 }
 ```

--- a/modules/terraform-aci-endpoint-security-group/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-security-group/examples/complete/README.md
@@ -78,6 +78,22 @@ module "aci_endpoint_security_group" {
       description = "foo"
     }
   ]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_esg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_esg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-endpoint-security-group/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-security-group/examples/complete/main.tf
@@ -64,4 +64,20 @@ module "aci_endpoint_security_group" {
       description = "foo"
     }
   ]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_esg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_esg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }

--- a/modules/terraform-aci-endpoint-security-group/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-security-group/examples/complete/main.tf
@@ -77,7 +77,8 @@ module "aci_endpoint_security_group" {
     tag  = "black"
   }]
   provider_esg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
 }

--- a/modules/terraform-aci-endpoint-security-group/main.tf
+++ b/modules/terraform-aci-endpoint-security-group/main.tf
@@ -127,3 +127,44 @@ resource "aci_rest_managed" "fvEPSelector" {
     aci_rest_managed.fvRsScope,
   ]
 }
+
+resource "aci_rest_managed" "vzProvLbl" {
+  for_each   = { for label in var.provider_esg_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvESg.dn}/provlbl-${each.value.name}"
+  class_name = "vzProvLbl"
+  content = {
+    name         = each.value.name
+    tag          = each.value.tag
+    isComplement = each.value.is_complement == true ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vzConsLbl" {
+  for_each   = { for label in var.consumer_esg_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvESg.dn}/conslbl-${each.value.name}"
+  class_name = "vzConsLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzProvSubjLbl" {
+  for_each   = { for label in var.provider_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvESg.dn}/provsubjlbl-${each.value.name}"
+  class_name = "vzProvSubjLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzConsSubjLbl" {
+  for_each   = { for label in var.consumer_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvESg.dn}/conssubjlbl-${each.value.name}"
+  class_name = "vzConsSubjLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}

--- a/modules/terraform-aci-endpoint-security-group/variables.tf
+++ b/modules/terraform-aci-endpoint-security-group/variables.tf
@@ -250,3 +250,97 @@ variable "ip_subnet_selectors" {
     error_message = "`description`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, }`, `~`, `?`, `&`, `+`. Maximum characters: 128."
   }
 }
+
+
+variable "provider_subject_labels" {
+  description = "List of Provided subject labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_subject_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "consumer_subject_labels" {
+  description = "List of Consumed subject labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_subject_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "provider_esg_labels" {
+  description = "List of Provided EPG labels."
+  type = list(object({
+    name          = string
+    tag           = string
+    is_complement = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_esg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_esg_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "consumer_esg_labels" {
+  description = "List of Consumed EPG labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_esg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_esg_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}

--- a/modules/terraform-aci-external-endpoint-group/README.md
+++ b/modules/terraform-aci-external-endpoint-group/README.md
@@ -39,6 +39,23 @@ module "aci_external_endpoint_group" {
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["ICON1"]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
+  }]
 }
 ```
 
@@ -73,6 +90,10 @@ module "aci_external_endpoint_group" {
 | <a name="input_contract_consumers"></a> [contract\_consumers](#input\_contract\_consumers) | List of contract consumers. | `list(string)` | `[]` | no |
 | <a name="input_contract_providers"></a> [contract\_providers](#input\_contract\_providers) | List of contract providers. | `list(string)` | `[]` | no |
 | <a name="input_contract_imported_consumers"></a> [contract\_imported\_consumers](#input\_contract\_imported\_consumers) | List of imported contract consumers. | `list(string)` | `[]` | no |
+| <a name="input_provider_subject_labels"></a> [provider\_subject\_labels](#input\_provider\_subject\_labels) | List of Provider subject labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_subject_labels"></a> [consumer\_subject\_labels](#input\_consumer\_subject\_labels) | List of Consumer subject labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_provider_epg_labels"></a> [provider\_epg\_labels](#input\_provider\_epg\_labels) | List of Provider EPG labels. | <pre>list(object({<br>    name          = string<br>    tag           = string<br>    is_complement = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_epg_labels"></a> [consumer\_epg\_labels](#input\_consumer\_epg\_labels) | List of Consumer EPG labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 
@@ -93,4 +114,8 @@ module "aci_external_endpoint_group" {
 | [aci_rest_managed.l3extRsSubnetToProfile](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extRsSubnetToRtSumm](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extSubnet](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-external-endpoint-group/examples/complete/README.md
+++ b/modules/terraform-aci-external-endpoint-group/examples/complete/README.md
@@ -42,6 +42,23 @@ module "aci_external_endpoint_group" {
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["ICON1"]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
+  }]
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-external-endpoint-group/examples/complete/main.tf
+++ b/modules/terraform-aci-external-endpoint-group/examples/complete/main.tf
@@ -28,4 +28,21 @@ module "aci_external_endpoint_group" {
   contract_consumers          = ["CON1"]
   contract_providers          = ["CON1"]
   contract_imported_consumers = ["ICON1"]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
+  }]
 }

--- a/modules/terraform-aci-external-endpoint-group/main.tf
+++ b/modules/terraform-aci-external-endpoint-group/main.tf
@@ -94,3 +94,44 @@ resource "aci_rest_managed" "l3extRsSubnetToRtSumm" {
     tDn = each.value.bgp_route_summarization ? (each.value.bgp_route_summarization_policy != "" ? "uni/tn-${var.tenant}/bgprtsum-${each.value.bgp_route_summarization_policy}" : "uni/tn-common/bgprtsum-default") : (each.value.ospf_route_summarization ? "uni/tn-common/ospfrtsumm-default" : (each.value.eigrp_route_summarization ? "uni/tn-common/eigrprtsumm-eigrp_pol" : null))
   }
 }
+
+resource "aci_rest_managed" "vzProvLbl" {
+  for_each   = { for label in var.provider_epg_labels : label.name => label }
+  dn         = "${aci_rest_managed.l3extInstP.dn}/provlbl-${each.value.name}"
+  class_name = "vzProvLbl"
+  content = {
+    name         = each.value.name
+    tag          = each.value.tag
+    isComplement = each.value.is_complement == true ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vzConsLbl" {
+  for_each   = { for label in var.consumer_epg_labels : label.name => label }
+  dn         = "${aci_rest_managed.l3extInstP.dn}/conslbl-${each.value.name}"
+  class_name = "vzConsLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzProvSubjLbl" {
+  for_each   = { for label in var.provider_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.l3extInstP.dn}/provsubjlbl-${each.value.name}"
+  class_name = "vzProvSubjLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzConsSubjLbl" {
+  for_each   = { for label in var.consumer_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.l3extInstP.dn}/conssubjlbl-${each.value.name}"
+  class_name = "vzConsSubjLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}

--- a/modules/terraform-aci-external-endpoint-group/variables.tf
+++ b/modules/terraform-aci-external-endpoint-group/variables.tf
@@ -210,3 +210,97 @@ variable "contract_imported_consumers" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+
+variable "provider_subject_labels" {
+  description = "List of Provider subject labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_subject_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "consumer_subject_labels" {
+  description = "List of Consumer subject labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_subject_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "provider_epg_labels" {
+  description = "List of Provider EPG labels."
+  type = list(object({
+    name          = string
+    tag           = string
+    is_complement = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_epg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_epg_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "consumer_epg_labels" {
+  description = "List of Consumer EPG labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_epg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_epg_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}

--- a/modules/terraform-aci-useg-endpoint-group/README.md
+++ b/modules/terraform-aci-useg-endpoint-group/README.md
@@ -78,6 +78,23 @@ module "aci_useg_endpoint_group" {
     from            = "1.2.2.10"
     to              = "1.2.2.100"
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_useg_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_useg_epg_labels = [{
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
+  }]
 }
 ```
 
@@ -124,6 +141,10 @@ module "aci_useg_endpoint_group" {
 | <a name="input_ip_statements"></a> [ip\_statements](#input\_ip\_statements) | IP Statements for IP type uSeg Attributes | <pre>list(object({<br>    name           = string<br>    use_epg_subnet = bool<br>    ip             = optional(string, "")<br>  }))</pre> | `[]` | no |
 | <a name="input_mac_statements"></a> [mac\_statements](#input\_mac\_statements) | MAC Statements for MAC type uSeg Attributes | <pre>list(object({<br>    name = string<br>    mac  = string<br>  }))</pre> | `[]` | no |
 | <a name="input_l4l7_address_pools"></a> [l4l7\_address\_pools](#input\_l4l7\_address\_pools) | List of EPG L4/L7 Address Pools. | <pre>list(object({<br>    name            = string<br>    gateway_address = string<br>    from            = optional(string, "")<br>    to              = optional(string, "")<br>  }))</pre> | `[]` | no |
+| <a name="input_provider_subject_labels"></a> [provider\_subject\_labels](#input\_provider\_subject\_labels) | List of Provided subject labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_subject_labels"></a> [consumer\_subject\_labels](#input\_consumer\_subject\_labels) | List of Consumed subject labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
+| <a name="input_provider_useg_epg_labels"></a> [provider\_useg\_epg\_labels](#input\_provider\_useg\_epg\_labels) | List of Provided EPG labels. | <pre>list(object({<br>    name          = string<br>    tag           = string<br>    is_complement = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_useg_epg_labels"></a> [consumer\_useg\_epg\_labels](#input\_consumer\_useg\_epg\_labels) | List of Consumed EPG labels. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 
@@ -164,4 +185,8 @@ module "aci_useg_endpoint_group" {
 | [aci_rest_managed.ipNexthopEpP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.tagInst](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAddrInst](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-useg-endpoint-group/examples/complete/README.md
+++ b/modules/terraform-aci-useg-endpoint-group/examples/complete/README.md
@@ -81,6 +81,23 @@ module "aci_useg_endpoint_group" {
     from            = "1.2.2.10"
     to              = "1.2.2.100"
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_useg_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_useg_epg_labels = [{
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
+  }]
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-useg-endpoint-group/examples/complete/main.tf
+++ b/modules/terraform-aci-useg-endpoint-group/examples/complete/main.tf
@@ -67,4 +67,21 @@ module "aci_useg_endpoint_group" {
     from            = "1.2.2.10"
     to              = "1.2.2.100"
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_useg_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_useg_epg_labels = [{
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
+  }]
 }

--- a/modules/terraform-aci-useg-endpoint-group/main.tf
+++ b/modules/terraform-aci-useg-endpoint-group/main.tf
@@ -298,3 +298,43 @@ resource "aci_rest_managed" "fvnsUcastAddrBlk" {
   }
 }
 
+resource "aci_rest_managed" "vzProvLbl" {
+  for_each   = { for label in var.provider_useg_epg_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/provlbl-${each.value.name}"
+  class_name = "vzProvLbl"
+  content = {
+    name         = each.value.name
+    tag          = each.value.tag
+    isComplement = each.value.is_complement == true ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vzConsLbl" {
+  for_each   = { for label in var.consumer_useg_epg_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/conslbl-${each.value.name}"
+  class_name = "vzConsLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzProvSubjLbl" {
+  for_each   = { for label in var.provider_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/provsubjlbl-${each.value.name}"
+  class_name = "vzProvSubjLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzConsSubjLbl" {
+  for_each   = { for label in var.consumer_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/conssubjlbl-${each.value.name}"
+  class_name = "vzConsSubjLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}

--- a/modules/terraform-aci-useg-endpoint-group/variables.tf
+++ b/modules/terraform-aci-useg-endpoint-group/variables.tf
@@ -395,3 +395,96 @@ variable "l4l7_address_pools" {
     error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "provider_subject_labels" {
+  description = "List of Provided subject labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_subject_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "consumer_subject_labels" {
+  description = "List of Consumed subject labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_subject_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "provider_useg_epg_labels" {
+  description = "List of Provided EPG labels."
+  type = list(object({
+    name          = string
+    tag           = string
+    is_complement = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_useg_epg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.provider_useg_epg_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}
+
+variable "consumer_useg_epg_labels" {
+  description = "List of Consumed EPG labels."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_useg_epg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", label.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for label in var.consumer_useg_epg_labels : label.tag == null || try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], label.tag), false)
+    ])
+    error_message = "`tag`: Allowed values are: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+}

--- a/modules/terraform-aci-vrf/README.md
+++ b/modules/terraform-aci-vrf/README.md
@@ -118,20 +118,23 @@ module "aci_vrf" {
     }]
   }]
   consumer_subject_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   provider_subject_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   consumer_epg_labels = [{
     name = "Label01"
     tag  = "black"
   }]
   provider_epg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
 }
 ```

--- a/modules/terraform-aci-vrf/README.md
+++ b/modules/terraform-aci-vrf/README.md
@@ -117,6 +117,22 @@ module "aci_vrf" {
       bgp_route_summarization_policy = "ABC"
     }]
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }
 ```
 
@@ -187,6 +203,10 @@ module "aci_vrf" {
 | <a name="input_leaked_internal_prefixes"></a> [leaked\_internal\_prefixes](#input\_leaked\_internal\_prefixes) | List of leaked internal prefixes. Default value `public`: false. | <pre>list(object({<br>    prefix = string<br>    public = optional(bool, false)<br>    destinations = optional(list(object({<br>      description = optional(string, "")<br>      tenant      = string<br>      vrf         = string<br>      public      = optional(bool)<br>    })), [])<br>  }))</pre> | `[]` | no |
 | <a name="input_leaked_external_prefixes"></a> [leaked\_external\_prefixes](#input\_leaked\_external\_prefixes) | List of leaked external prefixes. | <pre>list(object({<br>    prefix             = string<br>    from_prefix_length = optional(number)<br>    to_prefix_length   = optional(number)<br>    destinations = optional(list(object({<br>      description = optional(string, "")<br>      tenant      = string<br>      vrf         = string<br>    })), [])<br>  }))</pre> | `[]` | no |
 | <a name="input_route_summarization_policies"></a> [route\_summarization\_policies](#input\_route\_summarization\_policies) | List of route summarization policies. | <pre>list(object({<br>    name = string<br>    nodes = optional(list(object({<br>      id  = number<br>      pod = optional(number, 1)<br>    })), [])<br>    subnets = optional(list(object({<br>      prefix                         = string<br>      bgp_route_summarization_policy = optional(string, null)<br>    })), [])<br>  }))</pre> | `[]` | no |
+| <a name="input_provider_subject_labels"></a> [provider\_subject\_labels](#input\_provider\_subject\_labels) | List of vzAny Subject Label Providers. | <pre>list(object({<br>    name          = string<br>    tag           = string<br>    is_complement = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_subject_labels"></a> [consumer\_subject\_labels](#input\_consumer\_subject\_labels) | List of vzAny Subject Label Consumers. | <pre>list(object({<br>    name          = string<br>    tag           = string<br>    is_complement = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_provider_epg_labels"></a> [provider\_epg\_labels](#input\_provider\_epg\_labels) | List of vzAny EPG Label Providers. | <pre>list(object({<br>    name          = string<br>    tag           = string<br>    is_complement = optional(bool, false)<br>  }))</pre> | `[]` | no |
+| <a name="input_consumer_epg_labels"></a> [consumer\_epg\_labels](#input\_consumer\_epg\_labels) | List of vzAny EPG Label Consumers. | <pre>list(object({<br>    name = string<br>    tag  = string<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 
@@ -252,6 +272,10 @@ module "aci_vrf" {
 | [aci_rest_managed.rtdmcRsFilterToRtMapPol_ssm_range](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.rtdmcRsFilterToRtMapPol_static_rp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vzAny](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzConsSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vzProvSubjLbl](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vzRsAnyToCons](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vzRsAnyToConsIf](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vzRsAnyToProv](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-vrf/examples/complete/README.md
+++ b/modules/terraform-aci-vrf/examples/complete/README.md
@@ -120,6 +120,22 @@ module "aci_vrf" {
       bgp_route_summarization_policy = "ABC"
     }]
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-vrf/examples/complete/README.md
+++ b/modules/terraform-aci-vrf/examples/complete/README.md
@@ -121,20 +121,23 @@ module "aci_vrf" {
     }]
   }]
   consumer_subject_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   provider_subject_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   consumer_epg_labels = [{
     name = "Label01"
     tag  = "black"
   }]
   provider_epg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
 }
 ```

--- a/modules/terraform-aci-vrf/examples/complete/main.tf
+++ b/modules/terraform-aci-vrf/examples/complete/main.tf
@@ -107,19 +107,22 @@ module "aci_vrf" {
     }]
   }]
   consumer_subject_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   provider_subject_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
   consumer_epg_labels = [{
     name = "Label01"
     tag  = "black"
   }]
   provider_epg_labels = [{
-    name = "Label01"
-    tag  = "black"
+    name          = "Label01"
+    tag           = "black"
+    is_complement = false
   }]
 }

--- a/modules/terraform-aci-vrf/examples/complete/main.tf
+++ b/modules/terraform-aci-vrf/examples/complete/main.tf
@@ -106,4 +106,20 @@ module "aci_vrf" {
       bgp_route_summarization_policy = "ABC"
     }]
   }]
+  consumer_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_subject_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  consumer_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
+  provider_epg_labels = [{
+    name = "Label01"
+    tag  = "black"
+  }]
 }

--- a/modules/terraform-aci-vrf/main.tf
+++ b/modules/terraform-aci-vrf/main.tf
@@ -560,3 +560,48 @@ resource "aci_rest_managed" "fvRtSummSubnet" {
     }
   }
 }
+
+resource "aci_rest_managed" "vzProvLbl" {
+  for_each   = { for label in var.provider_epg_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvCtx.dn}/any/provlbl-${each.value.name}"
+  class_name = "vzProvLbl"
+
+  content = {
+    name         = each.value.name
+    tag          = each.value.tag
+    isComplement = each.value.is_complement ? "yes" : "no"
+  }
+}
+
+
+resource "aci_rest_managed" "vzConsLbl" {
+  for_each   = { for label in var.consumer_epg_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvCtx.dn}/any/conslbl-${each.value.name}"
+  class_name = "vzConsLbl"
+  content = {
+    name = each.value.name
+    tag  = each.value.tag
+  }
+}
+
+resource "aci_rest_managed" "vzProvSubjLbl" {
+  for_each   = { for label in var.provider_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvCtx.dn}/any/provsubjlbl-${each.value.name}"
+  class_name = "vzProvSubjLbl"
+  content = {
+    name         = each.value.name
+    tag          = each.value.tag
+    isComplement = each.value.is_complement ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vzConsSubjLbl" {
+  for_each   = { for label in var.consumer_subject_labels : label.name => label }
+  dn         = "${aci_rest_managed.fvCtx.dn}/any/conssubjlbl-${each.value.name}"
+  class_name = "vzConsSubjLbl"
+  content = {
+    name         = each.value.name
+    tag          = each.value.tag
+    isComplement = each.value.is_complement ? "yes" : "no"
+  }
+}

--- a/modules/terraform-aci-vrf/variables.tf
+++ b/modules/terraform-aci-vrf/variables.tf
@@ -636,3 +636,102 @@ variable "route_summarization_policies" {
     error_message = "`subnets.bgp_route_summarization_policy`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "provider_subject_labels" {
+  description = "List of vzAny Subject Label Providers."
+  type = list(object({
+    name          = string
+    tag           = string
+    is_complement = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for l in var.provider_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", l.name))
+    ])
+    error_message = "`vrf.provider_subject_labels.name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for l in var.provider_subject_labels : try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], l.tag), false)
+    ])
+    error_message = "`tag`: Allowed values: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+
+}
+
+variable "consumer_subject_labels" {
+  description = "List of vzAny Subject Label Consumers."
+  type = list(object({
+    name          = string
+    tag           = string
+    is_complement = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for l in var.consumer_subject_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", l.name))
+    ])
+    error_message = "`vrf.consumer_subject_labels.name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for l in var.consumer_subject_labels : try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], l.tag), false)
+    ])
+    error_message = "`tag`: Allowed values: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+
+}
+
+variable "provider_epg_labels" {
+  description = "List of vzAny EPG Label Providers."
+  type = list(object({
+    name          = string
+    tag           = string
+    is_complement = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for l in var.provider_epg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", l.name))
+    ])
+    error_message = "`vrf.provider_epg_labels.name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for l in var.provider_epg_labels : try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], l.tag), false)
+    ])
+    error_message = "`tag`: Allowed values: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+
+}
+
+variable "consumer_epg_labels" {
+  description = "List of vzAny EPG Label Consumers."
+  type = list(object({
+    name = string
+    tag  = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for l in var.consumer_epg_labels : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", l.name))
+    ])
+    error_message = "`vrf.consumer_epg_labels.name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for l in var.consumer_epg_labels : try(contains(["alice-blue", "antique-white", "aqua", "aquamarine", "azure", "beige", "bisque", "black", "blanched-almond", "blue", "blue-violet", "brown", "burlywood", "cadet-blue", "chartreuse", "chocolate", "coral", "cornflower-blue", "cornsilk", "crimson", "cyan", "dark-blue", "dark-cyan", "dark-goldenrod", "dark-gray", "dark-green", "dark-khaki", "dark-magenta", "dark-olive-green", "dark-orange", "dark-orchid", "dark-red", "dark-salmon", "dark-sea-green", "dark-slate-blue", "dark-slate-gray", "dark-turquoise", "dark-violet", "deep-pink", "deep-sky-blue", "dim-gray", "dodger-blue", "fire-brick", "floral-white", "forest-green", "fuchsia", "gainsboro", "ghost-white", "gold", "goldenrod", "gray", "green", "green-yellow", "honeydew", "hot-pink", "indian-red", "indigo", "ivory", "khaki", "lavender", "lavender-blush", "lawn-green", "lemon-chiffon", "light-blue", "light-coral", "light-cyan", "light-goldenrod-yellow", "light-gray", "light-green", "light-pink", "light-salmon", "light-sea-green", "light-sky-blue", "light-slate-gray", "light-steel-blue", "light-yellow", "lime", "lime-green", "linen", "magenta", "maroon", "medium-aquamarine", "medium-blue", "medium-orchid", "medium-purple", "medium-sea-green", "medium-slate-blue", "medium-spring-green", "medium-turquoise", "medium-violet-red", "midnight-blue", "mint-cream", "misty-rose", "moccasin", "navajo-white", "navy", "old-lace", "olive", "olive-drab", "orange", "orange-red", "orchid", "pale-goldenrod", "pale-green", "pale-turquoise", "pale-violet-red", "papaya-whip", "peachpuff", "peru", "pink", "plum", "powder-blue", "purple", "red", "rosy-brown", "royal-blue", "saddle-brown", "salmon", "sandy-brown", "sea-green", "seashell", "sienna", "silver", "sky-blue", "slate-blue", "slate-gray", "snow", "spring-green", "steel-blue", "tan", "teal", "thistle", "tomato", "turquoise", "violet", "wheat", "white", "white-smoke", "yellow", "yellow-green"], l.tag), false)
+    ])
+    error_message = "`tag`: Allowed values: `alice-blue`, `antique-white`, `aqua`, `aquamarine`, `azure`, `beige`, `bisque`, `black`, `blanched-almond`, `blue`, `blue-violet`, `brown`, `burlywood`, `cadet-blue`, `chartreuse`, `chocolate`, `coral`, `cornflower-blue`, `cornsilk`, `crimson`, `cyan`, `dark-blue`, `dark-cyan`, `dark-goldenrod`, `dark-gray`, `dark-green`, `dark-khaki`, `dark-magenta`, `dark-olive-green`, `dark-orange`, `dark-orchid`, `dark-red`, `dark-salmon`, `dark-sea-green`, `dark-slate-blue`, `dark-slate-gray`, `dark-turquoise`, `dark-violet`, `deep-pink`, `deep-sky-blue`, `dim-gray`, `dodger-blue`, `fire-brick`, `floral-white`, `forest-green`, `fuchsia`, `gainsboro`, `ghost-white`, `gold`, `goldenrod`, `gray`, `green`, `green-yellow`, `honeydew`, `hot-pink`, `indian-red`, `indigo`, `ivory`, `khaki`, `lavender`, `lavender-blush`, `lawn-green`, `lemon-chiffon`, `light-blue`, `light-coral`, `light-cyan`, `light-goldenrod-yellow`, `light-gray`, `light-green`, `light-pink`, `light-salmon`, `light-sea-green`, `light-sky-blue`, `light-slate-gray`, `light-steel-blue`, `light-yellow`, `lime`, `lime-green`, `linen`, `magenta`, `maroon`, `medium-aquamarine`, `medium-blue`, `medium-orchid`, `medium-purple`, `medium-sea-green`, `medium-slate-blue`, `medium-spring-green`, `medium-turquoise`, `medium-violet-red`, `midnight-blue`, `mint-cream`, `misty-rose`, `moccasin`, `navajo-white`, `navy`, `old-lace`, `olive`, `olive-drab`, `orange`, `orange-red`, `orchid`, `pale-goldenrod`, `pale-green`, `pale-turquoise`, `pale-violet-red`, `papaya-whip`, `peachpuff`, `peru`, `pink`, `plum`, `powder-blue`, `purple`, `red`, `rosy-brown`, `royal-blue`, `saddle-brown`, `salmon`, `sandy-brown`, `sea-green`, `seashell`, `sienna`, `silver`, `sky-blue`, `slate-blue`, `slate-gray`, `snow`, `spring-green`, `steel-blue`, `tan`, `teal`, `thistle`, `tomato`, `turquoise`, `violet`, `wheat`, `white`, `white-smoke`, `yellow`, `yellow-green`"
+  }
+
+}


### PR DESCRIPTION
Feature: Add labels to contract subjects and epg/esg

Allow use of epg and subject labels to have great control of contract enforcement.

M: terraform-aci-vrf - Allow labels to be added to vzany
M: terraform-aci-contract - Allow subject labels
M: terraform-aci-endpoint-group - Allow epg and subject labels
M: terraform-aci-external-endpoint-group - Allow epg and subject labels
M: terraform-aci-useg-endpoint-group - Allow epg and subject labels
M: terraform-aci-endpoint-security-group - Allow esg and subject labels
M: aci_tenants.tf - Add logic
M: defaults.yaml
