### PR TITLE
Update MacSec modules to include fabric settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ Additional example repositories:
 | <a name="module_aci_fabric_leaf_switch_profile_auto"></a> [aci\_fabric\_leaf\_switch\_profile\_auto](#module\_aci\_fabric\_leaf\_switch\_profile\_auto) | ./modules/terraform-aci-fabric-leaf-switch-profile | n/a |
 | <a name="module_aci_fabric_leaf_switch_profile_manual"></a> [aci\_fabric\_leaf\_switch\_profile\_manual](#module\_aci\_fabric\_leaf\_switch\_profile\_manual) | ./modules/terraform-aci-fabric-leaf-switch-profile | n/a |
 | <a name="module_aci_fabric_link_level_policy"></a> [aci\_fabric\_link\_level\_policy](#module\_aci\_fabric\_link\_level\_policy) | ./modules/terraform-aci-fabric-link-level-policy | n/a |
+| <a name="module_aci_fabric_macsec_interfaces_policy"></a> [aci\_fabric\_macsec\_interfaces\_policy](#module\_aci\_fabric\_macsec\_interfaces\_policy) | ./modules/terraform-aci-macsec-interfaces-policy | n/a |
+| <a name="module_aci_fabric_macsec_keychain_policies"></a> [aci\_fabric\_macsec\_keychain\_policies](#module\_aci\_fabric\_macsec\_keychain\_policies) | ./modules/terraform-aci-macsec-keychain-policies | n/a |
+| <a name="module_aci_fabric_macsec_parameters_policy"></a> [aci\_fabric\_macsec\_parameters\_policy](#module\_aci\_fabric\_macsec\_parameters\_policy) | ./modules/terraform-aci-macsec-parameters-policy | n/a |
 | <a name="module_aci_fabric_pod_policy_group"></a> [aci\_fabric\_pod\_policy\_group](#module\_aci\_fabric\_pod\_policy\_group) | ./modules/terraform-aci-fabric-pod-policy-group | n/a |
 | <a name="module_aci_fabric_pod_profile_auto"></a> [aci\_fabric\_pod\_profile\_auto](#module\_aci\_fabric\_pod\_profile\_auto) | ./modules/terraform-aci-fabric-pod-profile | n/a |
 | <a name="module_aci_fabric_pod_profile_manual"></a> [aci\_fabric\_pod\_profile\_manual](#module\_aci\_fabric\_pod\_profile\_manual) | ./modules/terraform-aci-fabric-pod-profile | n/a |

--- a/aci_access_policies.tf
+++ b/aci_access_policies.tf
@@ -320,6 +320,7 @@ locals {
     for mkc in try(local.access_policies.interface_policies.macsec_keychain_policies, []) : {
       name        = "${mkc.name}${local.defaults.apic.access_policies.interface_policies.macsec_keychain_policies.name_suffix}"
       description = try(mkc.description, "")
+      type        = "access"
       key_policies = [for kp in try(mkc.key_policies, []) : {
         name           = try(kp.name, "")
         key_name       = kp.key_name
@@ -338,6 +339,7 @@ module "aci_macsec_keychain_policies" {
 
   for_each     = { for mkc in try(local.macsec_keychain_policies, []) : mkc.name => mkc if local.modules.aci_macsec_keychain_policies && var.manage_access_policies }
   name         = "${each.value.name}${local.defaults.apic.access_policies.interface_policies.macsec_keychain_policies.name_suffix}"
+  type         = each.value.type
   description  = each.value.description
   key_policies = each.value.key_policies
 }

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -245,14 +245,17 @@ module "aci_fabric_pod_policy_group" {
 
   for_each                 = { for pg in try(local.fabric_policies.pod_policy_groups, []) : pg.name => pg if local.modules.aci_fabric_pod_policy_group && var.manage_fabric_policies }
   name                     = "${each.value.name}${local.defaults.apic.fabric_policies.pod_policy_groups.name_suffix}"
+  description              = try(each.value.description, "")
   snmp_policy              = try("${each.value.snmp_policy}${local.defaults.apic.fabric_policies.pod_policies.snmp_policies.name_suffix}", "")
   date_time_policy         = try("${each.value.date_time_policy}${local.defaults.apic.fabric_policies.pod_policies.date_time_policies.name_suffix}", "")
   management_access_policy = try("${each.value.management_access_policy}${local.defaults.apic.fabric_policies.pod_policies.management_access_policies.name_suffix}", "")
+  macsec_policy            = try("${each.value.macsec_policy}${local.defaults.apic.fabric_policies.pod_policies.macsec_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_snmp_policy,
     module.aci_date_time_policy,
     module.aci_management_access_policy,
+    module.aci_macsec_interfaces_policy,
   ]
 }
 
@@ -1051,4 +1054,65 @@ module "aci_sr_mpls_global_configuration" {
   count                   = local.modules.aci_sr_mpls_global_configuration == true && try(local.fabric_policies.sr_mpls_global_configuration.sr_global_block_minimum, local.fabric_policies.sr_mpls_global_configuration.sr_global_block_maximum, "") != "" && var.manage_fabric_policies ? 1 : 0
   sr_global_block_minimum = try(local.fabric_policies.sr_mpls_global_configuration.sr_global_block_minimum, local.defaults.apic.fabric_policies.sr_mpls_global_configuration.sr_global_block_minimum)
   sr_global_block_maximum = try(local.fabric_policies.sr_mpls_global_configuration.sr_global_block_maximum, local.defaults.apic.fabric_policies.sr_mpls_global_configuration.sr_global_block_maximum)
+}
+
+#####################
+
+module "aci_fabric_macsec_parameters_policy" {
+  source = "./modules/terraform-aci-macsec-parameters-policy"
+
+  for_each        = { for mpp in try(local.fabric_policies.macsec_policies.macsec_parameters_policies, []) : mpp.name => mpp if local.modules.aci_macsec_parameters_policy && var.manage_fabric_policies }
+  name            = "${each.value.name}${local.defaults.apic.fabric_policies.macsec_policies.macsec_parameters_policies.name_suffix}"
+  description     = try(each.value.description, "")
+  cipher_suite    = try(each.value.cipher_suite, local.defaults.apic.fabric_policies.macsec_policies.macsec_parameters_policies.cipher_suite)
+  window_size     = try(each.value.window_size, local.defaults.apic.fabric_policies.macsec_policies.macsec_parameters_policies.window_size)
+  key_expiry_time = try(each.value.key_expiry_time, local.defaults.apic.fabric_policies.macsec_policies.macsec_parameters_policies.key_expiry_time) == "disabled" || try(each.value.key_expiry_time, local.defaults.apic.fabric_policies.macsec_policies.macsec_parameters_policies.key_expiry_time) == 0 ? 0 : each.value.key_expiry_time
+  security_policy = try(each.value.security_policy, local.defaults.apic.fabric_policies.macsec_policies.macsec_parameters_policies.security_policy)
+  type            = local.defaults.apic.fabric_policies.macsec_policies.macsec_parameters_policies.type
+}
+
+locals {
+  fabric_macsec_keychain_policies = flatten([
+    for mkc in try(local.fabric_policies.macsec_policies.macsec_keychain_policies, []) : {
+      name        = "${mkc.name}${local.defaults.apic.fabric_policies.macsec_policies.macsec_keychain_policies.name_suffix}"
+      description = try(mkc.description, "")
+      type        = "fabric"
+      key_policies = [for kp in try(mkc.key_policies, []) : {
+        name           = try(kp.name, "")
+        key_name       = kp.key_name
+        pre_shared_key = kp.pre_shared_key
+        description    = try(kp.description, "")
+        start_time     = try(kp.start_time, local.defaults.apic.fabric_policies.macsec_policies.macsec_keychain_policies.key_policies.start_time)
+        end_time       = try(kp.end_time, local.defaults.apic.fabric_policies.macsec_policies.macsec_keychain_policies.key_policies.end_time)
+        }
+      ]
+    }
+  ])
+}
+
+module "aci_fabric_macsec_keychain_policies" {
+  source = "./modules/terraform-aci-macsec-keychain-policies"
+
+  for_each     = { for mkc in try(local.fabric_macsec_keychain_policies, []) : mkc.name => mkc if local.modules.aci_macsec_keychain_policies && var.manage_fabric_policies }
+  name         = "${each.value.name}${local.defaults.apic.fabric_policies.macsec_policies.macsec_keychain_policies.name_suffix}"
+  type         = each.value.type
+  description  = each.value.description
+  key_policies = each.value.key_policies
+}
+
+module "aci_fabric_macsec_interfaces_policy" {
+  source = "./modules/terraform-aci-macsec-interfaces-policy"
+
+  for_each                 = { for mip in try(local.fabric_policies.macsec_policies.macsec_interfaces_policies, []) : mip.name => mip if local.modules.aci_macsec_interfaces_policy && var.manage_fabric_policies }
+  name                     = "${each.value.name}${local.defaults.apic.fabric_policies.macsec_policies.macsec_interfaces_policies.name_suffix}"
+  description              = try(each.value.description, "")
+  admin_state              = try(each.value.admin_state, local.defaults.apic.fabric_policies.macsec_policies.macsec_interfaces_policies.admin_state)
+  macsec_keychain_policy   = "${each.value.macsec_keychain_policy}${local.defaults.apic.fabric_policies.macsec_policies.macsec_keychain_policies.name_suffix}"
+  macsec_parameters_policy = "${each.value.macsec_parameters_policy}${local.defaults.apic.fabric_policies.macsec_policies.macsec_parameters_policies.name_suffix}"
+  type                     = "fabric"
+
+  depends_on = [
+    module.aci_macsec_keychain_policies,
+    module.aci_macsec_parameters_policy
+  ]
 }

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -161,6 +161,8 @@ defaults:
           http:
             admin_state: false
             port: 80
+        macsec_policies:
+          name_suffix: ""
       switch_policies:
         node_control_policies:
           name_suffix: ""
@@ -404,7 +406,26 @@ defaults:
       sr_mpls_global_configuration:
         sr_global_block_minimum: 16000
         sr_global_block_maximum: 23999
-
+      macsec_policies:
+        macsec_parameters_policies:
+          name_suffix: ""
+          cipher_suite: gcm-aes-xpn-256
+          confidentiality_offset: offset-0
+          key_server_priority: 16
+          window_size: 64
+          key_expiry_time: disabled
+          security_policy: should-secure
+          type: fabric
+        macsec_keychain_policies:
+          name_suffix: ""
+          key_policies:
+            start_time: now
+            end_time: infinite
+          type: fabric
+        macsec_interfaces_policies:
+          name_suffix: ""
+          admin_state: true
+          type: fabric
     access_policies:
       leaf_switch_profile_name: "LEAF\\g<id>"
       leaf_interface_profile_name: "LEAF\\g<id>"

--- a/modules/terraform-aci-fabric-pod-policy-group/README.md
+++ b/modules/terraform-aci-fabric-pod-policy-group/README.md
@@ -17,6 +17,7 @@ module "aci_fabric_pod_policy_group" {
   snmp_policy              = "SNMP1"
   date_time_policy         = "DATE1"
   management_access_policy = "MAP1"
+  macsec_policy            = "MACSEC1"
 }
 ```
 
@@ -41,6 +42,8 @@ module "aci_fabric_pod_policy_group" {
 | <a name="input_snmp_policy"></a> [snmp\_policy](#input\_snmp\_policy) | SNMP policy name. | `string` | `""` | no |
 | <a name="input_date_time_policy"></a> [date\_time\_policy](#input\_date\_time\_policy) | Date time policy name. | `string` | `""` | no |
 | <a name="input_management_access_policy"></a> [management\_access\_policy](#input\_management\_access\_policy) | Management access policy name. | `string` | `""` | no |
+| <a name="input_description"></a> [description](#input\_description) | Pod policy description | `string` | `""` | no |
+| <a name="input_macsec_policy"></a> [macsec\_policy](#input\_macsec\_policy) | Pod MACsec Policy. | `string` | `""` | no |
 
 ## Outputs
 
@@ -55,6 +58,7 @@ module "aci_fabric_pod_policy_group" {
 |------|------|
 | [aci_rest_managed.fabricPodPGrp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricRsCommPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fabricRsMacsecPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricRsSnmpPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricRsTimePol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-pod-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-fabric-pod-policy-group/examples/complete/README.md
@@ -20,6 +20,7 @@ module "aci_fabric_pod_policy_group" {
   snmp_policy              = "SNMP1"
   date_time_policy         = "DATE1"
   management_access_policy = "MAP1"
+  macsec_policy            = "MACSEC1"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-pod-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-fabric-pod-policy-group/examples/complete/main.tf
@@ -6,4 +6,5 @@ module "aci_fabric_pod_policy_group" {
   snmp_policy              = "SNMP1"
   date_time_policy         = "DATE1"
   management_access_policy = "MAP1"
+  macsec_policy            = "MACSEC1"
 }

--- a/modules/terraform-aci-fabric-pod-policy-group/main.tf
+++ b/modules/terraform-aci-fabric-pod-policy-group/main.tf
@@ -2,7 +2,8 @@ resource "aci_rest_managed" "fabricPodPGrp" {
   dn         = "uni/fabric/funcprof/podpgrp-${var.name}"
   class_name = "fabricPodPGrp"
   content = {
-    name = var.name
+    name  = var.name
+    descr = var.description
   }
 }
 
@@ -27,5 +28,13 @@ resource "aci_rest_managed" "fabricRsCommPol" {
   class_name = "fabricRsCommPol"
   content = {
     tnCommPolName = var.management_access_policy
+  }
+}
+
+resource "aci_rest_managed" "fabricRsMacsecPol" {
+  dn         = "${aci_rest_managed.fabricPodPGrp.dn}/rsmacsecPol"
+  class_name = "fabricRsMacsecPol"
+  content = {
+    tnMacsecFabIfPolName = var.macsec_policy
   }
 }

--- a/modules/terraform-aci-fabric-pod-policy-group/variables.tf
+++ b/modules/terraform-aci-fabric-pod-policy-group/variables.tf
@@ -40,3 +40,25 @@ variable "management_access_policy" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "description" {
+  description = "Pod policy description"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]{0,128}$", var.description))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, }`, `~`, `?`, `&`, `+`. Maximum characters: 128."
+  }
+}
+
+variable "macsec_policy" {
+  description = "Pod MACsec Policy."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.macsec_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-macsec-interfaces-policy/README.md
+++ b/modules/terraform-aci-macsec-interfaces-policy/README.md
@@ -17,6 +17,7 @@ module "aci_macsec_interfaces_policy" {
   admin_state              = true
   macsec_parameters_policy = "macsec-parameter-policy"
   macsec_keychain_policy   = "macsec-keychain-policy"
+  type                     = "access"
 }
 ```
 
@@ -42,6 +43,7 @@ module "aci_macsec_interfaces_policy" {
 | <a name="input_admin_state"></a> [admin\_state](#input\_admin\_state) | The administrative state of the MACsec Interface Policy | `bool` | `true` | no |
 | <a name="input_macsec_parameters_policy"></a> [macsec\_parameters\_policy](#input\_macsec\_parameters\_policy) | MACsec Parameters Policy Name | `string` | n/a | yes |
 | <a name="input_macsec_keychain_policy"></a> [macsec\_keychain\_policy](#input\_macsec\_keychain\_policy) | MACsec KeyChain Policy Name | `string` | n/a | yes |
+| <a name="input_type"></a> [type](#input\_type) | Type of MacSec Interface Policy. Allowed values: `access` or `fabric`. | `string` | `"access"` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-macsec-interfaces-policy/examples/complete/README.md
+++ b/modules/terraform-aci-macsec-interfaces-policy/examples/complete/README.md
@@ -20,6 +20,7 @@ module "aci_macsec_interfaces_policy" {
   admin_state              = true
   macsec_parameters_policy = "macsec-parameter-policy"
   macsec_keychain_policy   = "macsec-keychain-policy"
+  type                     = "access"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-macsec-interfaces-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-macsec-interfaces-policy/examples/complete/main.tf
@@ -6,4 +6,5 @@ module "aci_macsec_interfaces_policy" {
   admin_state              = true
   macsec_parameters_policy = "macsec-parameter-policy"
   macsec_keychain_policy   = "macsec-keychain-policy"
+  type                     = "access"
 }

--- a/modules/terraform-aci-macsec-interfaces-policy/main.tf
+++ b/modules/terraform-aci-macsec-interfaces-policy/main.tf
@@ -1,6 +1,6 @@
 resource "aci_rest_managed" "macsecIfPol" {
-  dn         = "uni/infra/macsecifp-${var.name}"
-  class_name = "macsecIfPol"
+  dn         = var.type == "access" ? "uni/infra/macsecifp-${var.name}" : "uni/fabric/macsecfabifp-${var.name}"
+  class_name = var.type == "access" ? "macsecIfPol" : "macsecFabIfPol"
 
   content = {
     name    = var.name
@@ -14,7 +14,7 @@ resource "aci_rest_managed" "macsecRsToKeyChainPol" {
   class_name = "macsecRsToKeyChainPol"
 
   content = {
-    tDn = "uni/infra/macsecpcont/keychainp-${var.macsec_keychain_policy}"
+    tDn = var.type == "access" ? "uni/infra/macsecpcont/keychainp-${var.macsec_keychain_policy}" : "uni/fabric/macsecpcontfab/keychainp-${var.macsec_keychain_policy}"
   }
 }
 
@@ -23,6 +23,6 @@ resource "aci_rest_managed" "macsecRsToParamPol" {
   class_name = "macsecRsToParamPol"
 
   content = {
-    tDn = "uni/infra/macsecpcont/paramp-${var.macsec_parameters_policy}"
+    tDn = var.type == "access" ? "uni/infra/macsecpcont/paramp-${var.macsec_parameters_policy}" : "uni/fabric/macsecpcontfab/fabparamp-${var.macsec_parameters_policy}"
   }
 }

--- a/modules/terraform-aci-macsec-interfaces-policy/variables.tf
+++ b/modules/terraform-aci-macsec-interfaces-policy/variables.tf
@@ -44,3 +44,15 @@ variable "macsec_keychain_policy" {
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+
+variable "type" {
+  description = "Type of MacSec Interface Policy. Allowed values: `access` or `fabric`."
+  type        = string
+  default     = "access"
+
+  validation {
+    condition     = contains(["access", "fabric"], var.type)
+    error_message = "Allowed values are `access` or `fabric`."
+  }
+}

--- a/modules/terraform-aci-macsec-keychain-policies/README.md
+++ b/modules/terraform-aci-macsec-keychain-policies/README.md
@@ -15,6 +15,7 @@ module "aci_macsec_keychain_policies" {
 
   name        = "macsec-keychain-pol"
   description = "Keychain Description"
+  type        = "access"
   key_policies = [{
     name           = "keypolicy1"
     description    = "Key Policy Description"
@@ -46,6 +47,7 @@ module "aci_macsec_keychain_policies" {
 | <a name="input_name"></a> [name](#input\_name) | MACsec Key Policy Name | `string` | `""` | no |
 | <a name="input_description"></a> [description](#input\_description) | MACsec Policy description | `string` | `""` | no |
 | <a name="input_key_policies"></a> [key\_policies](#input\_key\_policies) | Key Polices for Key Chain | <pre>list(object({<br>    name           = string<br>    key_name       = string<br>    pre_shared_key = string<br>    description    = optional(string, "")<br>    start_time     = optional(string, "now")<br>    end_time       = optional(string, "infinite")<br>  }))</pre> | `[]` | no |
+| <a name="input_type"></a> [type](#input\_type) | Type of Keychain policy. Allowed values: `access` or `fabric`. | `string` | `"access"` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-macsec-keychain-policies/examples/complete/README.md
+++ b/modules/terraform-aci-macsec-keychain-policies/examples/complete/README.md
@@ -18,6 +18,7 @@ module "aci_macsec_keychain_policies" {
 
   name        = "macsec-keychain-pol"
   description = "Keychain Description"
+  type        = "access"
   key_policies = [{
     name           = "keypolicy1"
     description    = "Key Policy Description"

--- a/modules/terraform-aci-macsec-keychain-policies/examples/complete/main.tf
+++ b/modules/terraform-aci-macsec-keychain-policies/examples/complete/main.tf
@@ -4,6 +4,7 @@ module "aci_macsec_keychain_policies" {
 
   name        = "macsec-keychain-pol"
   description = "Keychain Description"
+  type        = "access"
   key_policies = [{
     name           = "keypolicy1"
     description    = "Key Policy Description"

--- a/modules/terraform-aci-macsec-keychain-policies/main.tf
+++ b/modules/terraform-aci-macsec-keychain-policies/main.tf
@@ -1,5 +1,5 @@
 resource "aci_rest_managed" "macsecKeyChainPol" {
-  dn         = "uni/infra/macsecpcont/keychainp-${var.name}"
+  dn         = var.type == "access" ? "uni/infra/macsecpcont/keychainp-${var.name}" : "uni/fabric/macsecpcontfab/keychainp-${var.name}"
   class_name = "macsecKeyChainPol"
   content = {
     name  = var.name

--- a/modules/terraform-aci-macsec-keychain-policies/variables.tf
+++ b/modules/terraform-aci-macsec-keychain-policies/variables.tf
@@ -60,3 +60,14 @@ variable "key_policies" {
     error_message = "`description`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, }`, `~`, `?`, `&`, `+`. Maximum characters: 128."
   }
 }
+
+variable "type" {
+  description = "Type of Keychain policy. Allowed values: `access` or `fabric`."
+  type        = string
+  default     = "access"
+
+  validation {
+    condition     = contains(["access", "fabric"], var.type)
+    error_message = "Allowed values are `access` or `fabric`."
+  }
+}

--- a/modules/terraform-aci-macsec-parameters-policy/README.md
+++ b/modules/terraform-aci-macsec-parameters-policy/README.md
@@ -21,6 +21,7 @@ module "aci_macsec_parameters_policy" {
   window_size            = 1024
   key_expiry_time        = 120
   security_policy        = "must-secure"
+  type                   = "access"
 }
 ```
 
@@ -49,6 +50,7 @@ module "aci_macsec_parameters_policy" {
 | <a name="input_window_size"></a> [window\_size](#input\_window\_size) | Replay Protection Window Size. Minimum value: `0`. Maximum value `4294967295`. Default: `64` | `number` | `64` | no |
 | <a name="input_key_expiry_time"></a> [key\_expiry\_time](#input\_key\_expiry\_time) | SAK Expiry Time (in seconds). Values are `0` (disabled); or Minimum value `60`, Maximum value `2592000` | `number` | `0` | no |
 | <a name="input_security_policy"></a> [security\_policy](#input\_security\_policy) | Security Policy. Choices are: `must-secure` or `should-secure`. | `string` | `"should-secure"` | no |
+| <a name="input_type"></a> [type](#input\_type) | Type of Parameter Policy. Allowed values: `access` or `fabric`. | `string` | `"access"` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-macsec-parameters-policy/examples/complete/README.md
+++ b/modules/terraform-aci-macsec-parameters-policy/examples/complete/README.md
@@ -24,6 +24,7 @@ module "aci_macsec_parameters_policy" {
   window_size            = 1024
   key_expiry_time        = 120
   security_policy        = "must-secure"
+  type                   = "access"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-macsec-parameters-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-macsec-parameters-policy/examples/complete/main.tf
@@ -10,4 +10,5 @@ module "aci_macsec_parameters_policy" {
   window_size            = 1024
   key_expiry_time        = 120
   security_policy        = "must-secure"
+  type                   = "access"
 }

--- a/modules/terraform-aci-macsec-parameters-policy/main.tf
+++ b/modules/terraform-aci-macsec-parameters-policy/main.tf
@@ -1,11 +1,11 @@
 resource "aci_rest_managed" "macsecParamPol" {
-  dn         = "uni/infra/macsecpcont/paramp-${var.name}"
-  class_name = "macsecParamPol"
+  dn         = var.type == "access" ? "uni/infra/macsecpcont/paramp-${var.name}" : "uni/fabric/macsecpcontfab/fabparamp-${var.name}"
+  class_name = var.type == "access" ? "macsecParamPol" : "macsecFabParamPol"
   content = {
     name          = var.name
     descr         = var.description
-    confOffset    = var.confidentiality_offset
-    keySvrPrio    = var.key_server_priority
+    confOffset    = var.type == "access" ? var.confidentiality_offset : null
+    keySvrPrio    = var.type == "access" ? var.key_server_priority : null
     cipherSuite   = var.cipher_suite
     replayWindow  = var.window_size
     sakExpiryTime = var.key_expiry_time == 0 ? "disabled" : var.key_expiry_time

--- a/modules/terraform-aci-macsec-parameters-policy/variables.tf
+++ b/modules/terraform-aci-macsec-parameters-policy/variables.tf
@@ -83,3 +83,14 @@ variable "security_policy" {
     error_message = "Allowed values: `must-secure` or `should-secure`."
   }
 }
+
+variable "type" {
+  description = "Type of Parameter Policy. Allowed values: `access` or `fabric`."
+  type        = string
+  default     = "access"
+
+  validation {
+    condition     = contains(["access", "fabric"], var.type)
+    error_message = "Allowed values are `access` or `fabric`."
+  }
+}


### PR DESCRIPTION
M: Update macsec modules to include fabric settings
M: Update fabric-pod-policy-group for macsec interface profile [ Fix for #175 ]

Looking for insight around my use of the `type` variable.  I went back and forth on whether to add it to defaults since the intent is to force a policy type (access vs fabric) depending on where the module is called from (access_policies.tf vs fabric_policies.tf).  I don't know if it makes sense to give the user the ability to override that via defaults and data model input.