### PR TITLE
M: `terraform-aci-syslog-policy` to allow for RFC5424-TS syslog format

### DIFF
--- a/modules/terraform-aci-syslog-policy/README.md
+++ b/modules/terraform-aci-syslog-policy/README.md
@@ -57,7 +57,7 @@ module "aci_syslog_policy" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Syslog policy name. | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | Description. | `string` | `""` | no |
-| <a name="input_format"></a> [format](#input\_format) | Format. Choices: `aci`, `nxos`. | `string` | `"aci"` | no |
+| <a name="input_format"></a> [format](#input\_format) | Format. Choices: `aci`, `nxos`, `rfc5424-ts`. | `string` | `"aci"` | no |
 | <a name="input_show_millisecond"></a> [show\_millisecond](#input\_show\_millisecond) | Show milliseconds. | `bool` | `false` | no |
 | <a name="input_show_timezone"></a> [show\_timezone](#input\_show\_timezone) | Show timezone. | `bool` | `false` | no |
 | <a name="input_admin_state"></a> [admin\_state](#input\_admin\_state) | Admin state. | `bool` | `true` | no |

--- a/modules/terraform-aci-syslog-policy/variables.tf
+++ b/modules/terraform-aci-syslog-policy/variables.tf
@@ -20,13 +20,13 @@ variable "description" {
 }
 
 variable "format" {
-  description = "Format. Choices: `aci`, `nxos`."
+  description = "Format. Choices: `aci`, `nxos`, `rfc5424-ts`."
   type        = string
   default     = "aci"
 
   validation {
-    condition     = contains(["aci", "nxos"], var.format)
-    error_message = "Allowed values are `aci` or `nxos`."
+    condition     = contains(["aci", "nxos", "rfc5424-ts"], var.format)
+    error_message = "Allowed values are `aci`, `nxos` or `rfc5424-ts`."
   }
 }
 
@@ -128,9 +128,9 @@ variable "destinations" {
 
   validation {
     condition = alltrue([
-      for d in var.destinations : d.format == null || try(contains(["aci", "nxos"], d.format), false)
+      for d in var.destinations : d.format == null || try(contains(["aci", "nxos", "rfc5424-ts"], d.format), false)
     ])
-    error_message = "`format`: Allowed values are `aci` or `nxos`."
+    error_message = "`format`: Allowed values are `aci`, `nxos`, or `rfc5424-ts`."
   }
 
   validation {


### PR DESCRIPTION
Update requires only validation of new format value `rfc5424-ts`

This is for Enhancements: Please add format enhanced in syslog in addition to nx-os and aci #189