### PR TITLE
changed var.name to port_channel_member_policy

### DIFF
--- a/modules/terraform-aci-access-leaf-interface-policy-group/main.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/main.tf
@@ -92,10 +92,10 @@ resource "aci_rest_managed" "infraRsLacpPol" {
 
 resource "aci_rest_managed" "infraAccBndlSubgrp" {
   count      = (var.type == "vpc" || var.type == "pc") && var.port_channel_member_policy != "" ? 1 : 0
-  dn         = "${aci_rest_managed.infraAccGrp.dn}/accsubbndl-${var.name}"
+  dn         = "${aci_rest_managed.infraAccGrp.dn}/accsubbndl-${var.port_channel_member_policy}"
   class_name = "infraAccBndlSubgrp"
   content = {
-    name = var.name
+    name = var.port_channel_member_policy
   }
 }
 


### PR DESCRIPTION
changed var.name to port_channel_member_policy so parent policy name is not being copied for child policy + ran pre-commit