### PR TITLE
Revert "L3out OSPF Interface Profile auth limitation"

### DIFF
--- a/modules/terraform-aci-l3out-interface-profile/variables.tf
+++ b/modules/terraform-aci-l3out-interface-profile/variables.tf
@@ -76,11 +76,6 @@ variable "ospf_authentication_key" {
   type        = string
   default     = ""
   sensitive   = true
-
-  validation {
-    condition     = can(regex((var.ospf_authentication_type == "simple" ? "^.{0,8}$" : "^.{0,16}$"), var.ospf_authentication_key))
-    error_message = "Maximum characters for specific auth_type is: [simple: 8, md5: 16]"
-  }
 }
 
 variable "ospf_authentication_key_id" {


### PR DESCRIPTION
Reverts netascode/terraform-aci-nac-aci#179. Referring to other variable in validation is supported since tf 1.9.0