### PR TITLE
Endpoint retention policy support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -190,6 +190,10 @@ repos:
       - id: terraform-docs-system
         args: ["./modules/terraform-aci-infra-dhcp-relay-policy/examples/complete"]
       - id: terraform-docs-system
+        args: ["./modules/terraform-aci-endpoint-retention-policy"]
+      - id: terraform-docs-system
+        args: ["./modules/terraform-aci-endpoint-retention-policy/examples/complete"]
+      - id: terraform-docs-system
         args: ["./modules/terraform-aci-dns-policy"]
       - id: terraform-docs-system
         args: ["./modules/terraform-aci-dns-policy/examples/complete"]

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Additional example repositories:
 | <a name="module_aci_endpoint_ip_tag_policy"></a> [aci\_endpoint\_ip\_tag\_policy](#module\_aci\_endpoint\_ip\_tag\_policy) | ./modules/terraform-aci-endpoint-ip-tag-policy | n/a |
 | <a name="module_aci_endpoint_loop_protection"></a> [aci\_endpoint\_loop\_protection](#module\_aci\_endpoint\_loop\_protection) | ./modules/terraform-aci-endpoint-loop-protection | n/a |
 | <a name="module_aci_endpoint_mac_tag_policy"></a> [aci\_endpoint\_mac\_tag\_policy](#module\_aci\_endpoint\_mac\_tag\_policy) | ./modules/terraform-aci-endpoint-mac-tag-policy | n/a |
+| <a name="module_aci_endpoint_retention_policy"></a> [aci\_endpoint\_retention\_policy](#module\_aci\_endpoint\_retention\_policy) | ./modules/terraform-aci-endpoint-retention-policy | n/a |
 | <a name="module_aci_endpoint_security_group"></a> [aci\_endpoint\_security\_group](#module\_aci\_endpoint\_security\_group) | ./modules/terraform-aci-endpoint-security-group | n/a |
 | <a name="module_aci_error_disabled_recovery"></a> [aci\_error\_disabled\_recovery](#module\_aci\_error\_disabled\_recovery) | ./modules/terraform-aci-error-disabled-recovery | n/a |
 | <a name="module_aci_external_connectivity_policy"></a> [aci\_external\_connectivity\_policy](#module\_aci\_external\_connectivity\_policy) | ./modules/terraform-aci-external-connectivity-policy | n/a |

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -2281,15 +2281,15 @@ locals {
   endpoint_retention_policies = flatten([
     for tenant in local.tenants : [
       for policy in try(tenant.policies.endpoint_retention_policies, []) : {
-        key                   = format("%s/%s", tenant.name, policy.name)
-        tenant                = tenant.name
-        name                  = "${policy.name}${local.defaults.apic.tenants.policies.endpoint_retention_policies.name_suffix}"
-        description           = try(policy.description, "")
-        hold_interval         = try(policy.hold_interval, local.defaults.apic.tenants.policies.endpoint_retention_policies.hold_interval)
-        bounce_entry_aging    = try(policy.bounce_entry_aging, local.defaults.apic.tenants.policies.endpoint_retention_policies.bounce_entry_aging)
-        local_endpoint_aging  = try(policy.local_endpoint_aging, local.defaults.apic.tenants.policies.endpoint_retention_policies.local_endpoint_aging)
-        remote_endpoint_aging = try(policy.remote_endpoint_aging, local.defaults.apic.tenants.policies.endpoint_retention_policies.remote_endpoint_aging)
-        move_frequency        = try(policy.move_frequency, local.defaults.apic.tenants.policies.endpoint_retention_policies.move_frequency)
+        key                            = format("%s/%s", tenant.name, policy.name)
+        tenant                         = tenant.name
+        name                           = "${policy.name}${local.defaults.apic.tenants.policies.endpoint_retention_policies.name_suffix}"
+        description                    = try(policy.description, "")
+        hold_interval                  = try(policy.hold_interval, local.defaults.apic.tenants.policies.endpoint_retention_policies.hold_interval)
+        bounce_entry_aging_interval    = try(policy.bounce_entry_aging_interval, local.defaults.apic.tenants.policies.endpoint_retention_policies.bounce_entry_aging_interval)
+        local_endpoint_aging_interval  = try(policy.local_endpoint_aging_interval, local.defaults.apic.tenants.policies.endpoint_retention_policies.local_endpoint_aging_interval)
+        remote_endpoint_aging_interval = try(policy.remote_endpoint_aging_interval, local.defaults.apic.tenants.policies.endpoint_retention_policies.remote_endpoint_aging_interval)
+        move_frequency                 = try(policy.move_frequency, local.defaults.apic.tenants.policies.endpoint_retention_policies.move_frequency)
       }
     ]
   ])
@@ -2298,15 +2298,15 @@ locals {
 module "aci_endpoint_retention_policy" {
   source = "./modules/terraform-aci-endpoint-retention-policy"
 
-  for_each              = { for policy in local.endpoint_retention_policies : policy.key => policy if local.modules.aci_endpoint_retention_policy && var.manage_tenants }
-  tenant                = each.value.tenant
-  name                  = each.value.name
-  description           = each.value.description
-  hold_interval         = each.value.hold_interval
-  bounce_entry_aging    = each.value.bounce_entry_aging
-  local_endpoint_aging  = each.value.local_endpoint_aging
-  remote_endpoint_aging = each.value.remote_endpoint_aging
-  move_frequency        = each.value.move_frequency
+  for_each                       = { for policy in local.endpoint_retention_policies : policy.key => policy if local.modules.aci_endpoint_retention_policy && var.manage_tenants }
+  tenant                         = each.value.tenant
+  name                           = each.value.name
+  description                    = each.value.description
+  hold_interval                  = each.value.hold_interval
+  bounce_entry_aging_interval    = each.value.bounce_entry_aging_interval
+  local_endpoint_aging_interval  = each.value.local_endpoint_aging_interval
+  remote_endpoint_aging_interval = each.value.remote_endpoint_aging_interval
+  move_frequency                 = each.value.move_frequency
 
   depends_on = [
     module.aci_tenant,

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -172,7 +172,8 @@ module "aci_vrf" {
     module.aci_contract,
     module.aci_imported_contract,
     module.aci_bgp_timer_policy,
-    module.aci_bgp_route_summarization_policy
+    module.aci_bgp_route_summarization_policy,
+    module.aci_endpoint_retention_policy,
   ]
 }
 
@@ -273,6 +274,7 @@ module "aci_bridge_domain" {
     module.aci_l3out,
     module.aci_dhcp_relay_policy,
     module.aci_dhcp_option_policy,
+    module.aci_endpoint_retention_policy,
   ]
 }
 

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1457,9 +1457,9 @@ defaults:
         endpoint_retention_policies:
           name_suffix: ""
           hold_interval: 300
-          bounce_entry_aging: 630
-          local_endpoint_aging: 900
-          remote_endpoint_aging: 300
+          bounce_entry_aging_interval: 630
+          local_endpoint_aging_interval: 900
+          remote_endpoint_aging_interval: 300
           move_frequrency: 256
       services:
         l4l7_devices:

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1454,6 +1454,13 @@ defaults:
           weight_down: 1
         endpoint_mac_tags:
           bridge_domain: all
+        endpoint_retention_policies:
+          name_suffix: ""
+          hold_interval: 300
+          bounce_entry_aging: 630
+          local_endpoint_aging: 900
+          remote_endpoint_aging: 300
+          move_frequrency: 256
       services:
         l4l7_devices:
           name_suffix: ""

--- a/defaults/modules.yaml
+++ b/defaults/modules.yaml
@@ -47,6 +47,7 @@ modules:
   aci_useg_endpoint_group: true
   aci_endpoint_loop_protection: true
   aci_endpoint_security_group: true
+  aci_endpoint_retention_policy: true
   aci_endpoint_mac_tag_policy: true
   aci_endpoint_ip_tag_policy: true
   aci_eigrp_interface_policy: true

--- a/modules/terraform-aci-bridge-domain/README.md
+++ b/modules/terraform-aci-bridge-domain/README.md
@@ -33,6 +33,7 @@ module "aci_bridge_domain" {
   unknown_ipv6_multicast     = "opt-flood"
   vrf                        = "VRF1"
   nd_interface_policy        = "ND_INTF_POL1"
+  endpoint_retention_policy  = "ERP1"
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.1.1.1/24"
@@ -103,6 +104,7 @@ module "aci_bridge_domain" {
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets. Default value `primary_ip`: `false`. Default value `public`: `false`. Default value `shared`: `false`. Default value `igmp_querier`: `false`. Default value `nd_ra_prefix`: `true`. Default value `no_default_gateway`: `false`. Default value `virtual`: `false`. | <pre>list(object({<br/>    description           = optional(string, "")<br/>    ip                    = string<br/>    primary_ip            = optional(bool, false)<br/>    public                = optional(bool, false)<br/>    shared                = optional(bool, false)<br/>    igmp_querier          = optional(bool, false)<br/>    nd_ra_prefix          = optional(bool, true)<br/>    no_default_gateway    = optional(bool, false)<br/>    virtual               = optional(bool, false)<br/>    nd_ra_prefix_policy   = optional(string, "")<br/>    ip_dataplane_learning = optional(bool, null)<br/>    tags = optional(list(object({<br/>      key   = string<br/>      value = string<br/>    })), [])<br/>  }))</pre> | `[]` | no |
 | <a name="input_l3outs"></a> [l3outs](#input\_l3outs) | List of l3outs | `list(string)` | `[]` | no |
 | <a name="input_dhcp_labels"></a> [dhcp\_labels](#input\_dhcp\_labels) | List of DHCP labels | <pre>list(object({<br/>    dhcp_relay_policy  = string<br/>    dhcp_option_policy = optional(string)<br/>    scope              = optional(string, "tenant")<br/>  }))</pre> | `[]` | no |
+| <a name="input_endpoint_retention_policy"></a> [endpoint\_retention\_policy](#input\_endpoint\_retention\_policy) | Endpoint Retention Policy. | `string` | `""` | no |
 
 ## Outputs
 
@@ -120,6 +122,7 @@ module "aci_bridge_domain" {
 | [aci_rest_managed.fvBD](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsBDToNdP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsBDToOut](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvRsBdToEpRet](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtx](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsIgmpsn](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsNdPfxPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-bridge-domain/examples/complete/README.md
+++ b/modules/terraform-aci-bridge-domain/examples/complete/README.md
@@ -36,6 +36,7 @@ module "aci_bridge_domain" {
   unknown_ipv6_multicast     = "opt-flood"
   vrf                        = "VRF1"
   nd_interface_policy        = "ND_INTF_POL1"
+  endpoint_retention_policy  = "ERP1"
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.1.1.1/24"

--- a/modules/terraform-aci-bridge-domain/examples/complete/main.tf
+++ b/modules/terraform-aci-bridge-domain/examples/complete/main.tf
@@ -22,6 +22,7 @@ module "aci_bridge_domain" {
   unknown_ipv6_multicast     = "opt-flood"
   vrf                        = "VRF1"
   nd_interface_policy        = "ND_INTF_POL1"
+  endpoint_retention_policy  = "ERP1"
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.1.1.1/24"

--- a/modules/terraform-aci-bridge-domain/main.tf
+++ b/modules/terraform-aci-bridge-domain/main.tf
@@ -193,3 +193,12 @@ resource "aci_rest_managed" "fvRsBDToNdP" {
     tnNdIfPolName = var.nd_interface_policy
   }
 }
+
+resource "aci_rest_managed" "fvRsBdToEpRet" {
+  count      = var.endpoint_retention_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fvBD.dn}/rsbdToEpRet"
+  class_name = "fvRsBdToEpRet"
+  content = {
+    tnFvEpRetPolName = var.endpoint_retention_policy
+  }
+}

--- a/modules/terraform-aci-bridge-domain/variables.tf
+++ b/modules/terraform-aci-bridge-domain/variables.tf
@@ -303,3 +303,14 @@ variable "dhcp_labels" {
     error_message = "`dhcp_option_policy`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "endpoint_retention_policy" {
+  description = "Endpoint Retention Policy."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.endpoint_retention_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-endpoint-retention-policy/.terraform-docs.yml
+++ b/modules/terraform-aci-endpoint-retention-policy/.terraform-docs.yml
@@ -1,0 +1,34 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Terraform ACI Endpoint Retention Policy Module
+
+  Manages ACI Endpoint Retention Policy
+
+  Location in GUI:
+  `Tenants` » `XXX` » `Policies` » `Protocol` » `End Point Retention`
+
+  ## Examples
+
+  ```hcl
+  {{ include "./examples/complete/main.tf" }}
+  ```
+
+  {{ .Requirements }}
+
+  {{ .Providers }}
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Resources }}
+
+output:
+  file: README.md
+  mode: replace
+
+sort:
+  enabled: false

--- a/modules/terraform-aci-endpoint-retention-policy/README.md
+++ b/modules/terraform-aci-endpoint-retention-policy/README.md
@@ -46,7 +46,7 @@ module "aci_end_point_retention_policy" {
 | <a name="input_bounce_entry_aging"></a> [bounce\_entry\_aging](#input\_bounce\_entry\_aging) | APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535. Value 0 = infinite. | `number` | `630` | no |
 | <a name="input_local_endpoint_aging"></a> [local\_endpoint\_aging](#input\_local\_endpoint\_aging) | APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite. | `number` | `900` | no |
 | <a name="input_remote_endpoint_aging"></a> [remote\_endpoint\_aging](#input\_remote\_endpoint\_aging) | APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite. | `number` | `300` | no |
-| <a name="input_move_frequency"></a> [move\_frequency](#input\_move\_frequency) | APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. Value 0 = none. | `number` | `300` | no |
+| <a name="input_move_frequency"></a> [move\_frequency](#input\_move\_frequency) | APIC Endpoint Retention move frequency. Minimum value: 5. Maximum value: 65535. Value 0 = none. | `number` | `300` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-endpoint-retention-policy/README.md
+++ b/modules/terraform-aci-endpoint-retention-policy/README.md
@@ -10,15 +10,15 @@ Location in GUI:
 
 ```hcl
 module "aci_end_point_retention_policy" {
-  source                = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
-  version               = ">= 0.9.4"
-  name                  = "ERP1"
-  descr                 = "Terraform"
-  hold_interval         = 6
-  bounce_entry_aging    = 630
-  local_endpoint_aging  = 900
-  remote_endpoint_aging = 300
-  move_frequency        = 256
+  source                         = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
+  version                        = ">= 0.9.4"
+  name                           = "ERP1"
+  descr                          = "Terraform"
+  hold_interval                  = 6
+  bounce_entry_aging_interval    = 630
+  local_endpoint_aging_interval  = 900
+  remote_endpoint_aging_interval = 300
+  move_frequency                 = 256
 }
 ```
 
@@ -27,13 +27,13 @@ module "aci_end_point_retention_policy" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.15.0 |
 
 ## Inputs
 
@@ -43,9 +43,9 @@ module "aci_end_point_retention_policy" {
 | <a name="input_name"></a> [name](#input\_name) | Endpoint Retention policy name. | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | Description. | `string` | `""` | no |
 | <a name="input_hold_interval"></a> [hold\_interval](#input\_hold\_interval) | APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. | `number` | `300` | no |
-| <a name="input_bounce_entry_aging"></a> [bounce\_entry\_aging](#input\_bounce\_entry\_aging) | APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535. Value 0 = infinite. | `number` | `630` | no |
-| <a name="input_local_endpoint_aging"></a> [local\_endpoint\_aging](#input\_local\_endpoint\_aging) | APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite. | `number` | `900` | no |
-| <a name="input_remote_endpoint_aging"></a> [remote\_endpoint\_aging](#input\_remote\_endpoint\_aging) | APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite. | `number` | `300` | no |
+| <a name="input_bounce_entry_aging_interval"></a> [bounce\_entry\_aging\_interval](#input\_bounce\_entry\_aging\_interval) | APIC Endpoint Retention bounce entry aging interval. Minimum value: 150. Maximum value: 65535. Value 0 = infinite. | `number` | `630` | no |
+| <a name="input_local_endpoint_aging_interval"></a> [local\_endpoint\_aging\_interval](#input\_local\_endpoint\_aging\_interval) | APIC Endpoint Retention local endpoint agin interval. Minimum value: 120. Maximum value: 65535. Value 0 = infinite. | `number` | `900` | no |
+| <a name="input_remote_endpoint_aging_interval"></a> [remote\_endpoint\_aging\_interval](#input\_remote\_endpoint\_aging\_interval) | APIC Endpoint Retention remote endpoint aging interval. Minimum value: 120. Maximum value: 65535. Value 0 = infinite. | `number` | `300` | no |
 | <a name="input_move_frequency"></a> [move\_frequency](#input\_move\_frequency) | APIC Endpoint Retention move frequency. Minimum value: 5. Maximum value: 65535. Value 0 = none. | `number` | `300` | no |
 
 ## Outputs

--- a/modules/terraform-aci-endpoint-retention-policy/README.md
+++ b/modules/terraform-aci-endpoint-retention-policy/README.md
@@ -1,0 +1,63 @@
+<!-- BEGIN_TF_DOCS -->
+# Terraform ACI Endpoint Retention Policy Module
+
+Manages ACI Endpoint Retention Policy
+
+Location in GUI:
+`Tenants` » `XXX` » `Policies` » `Protocol` » `End Point Retention`
+
+## Examples
+
+```hcl
+module "aci_end_point_retention_policy" {
+  source                = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
+  version               = ">= 0.9.4"
+  name                  = "ERP1"
+  descr                 = "Terraform"
+  hold_interval         = 6
+  bounce_entry_aging    = 630
+  local_endpoint_aging  = 900
+  remote_endpoint_aging = 300
+  move_frequency        = 256
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_tenant"></a> [tenant](#input\_tenant) | Tenant name. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Endpoint Retention policy name. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | Description. | `string` | `""` | no |
+| <a name="input_hold_interval"></a> [hold\_interval](#input\_hold\_interval) | APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. | `number` | `300` | no |
+| <a name="input_bounce_entry_aging"></a> [bounce\_entry\_aging](#input\_bounce\_entry\_aging) | APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535. | `number` | `630` | no |
+| <a name="input_local_endpoint_aging"></a> [local\_endpoint\_aging](#input\_local\_endpoint\_aging) | APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535. | `number` | `900` | no |
+| <a name="input_remote_endpoint_aging"></a> [remote\_endpoint\_aging](#input\_remote\_endpoint\_aging) | APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535. | `number` | `300` | no |
+| <a name="input_move_frequency"></a> [move\_frequency](#input\_move\_frequency) | APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. | `number` | `300` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dn"></a> [dn](#output\_dn) | Distinguished name of `fvEpRetPol` object. |
+| <a name="output_name"></a> [name](#output\_name) | Endpoint Retention policy name. |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aci_rest_managed.fvEpRetPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-endpoint-retention-policy/README.md
+++ b/modules/terraform-aci-endpoint-retention-policy/README.md
@@ -43,10 +43,10 @@ module "aci_end_point_retention_policy" {
 | <a name="input_name"></a> [name](#input\_name) | Endpoint Retention policy name. | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | Description. | `string` | `""` | no |
 | <a name="input_hold_interval"></a> [hold\_interval](#input\_hold\_interval) | APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. | `number` | `300` | no |
-| <a name="input_bounce_entry_aging"></a> [bounce\_entry\_aging](#input\_bounce\_entry\_aging) | APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535. | `number` | `630` | no |
-| <a name="input_local_endpoint_aging"></a> [local\_endpoint\_aging](#input\_local\_endpoint\_aging) | APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535. | `number` | `900` | no |
-| <a name="input_remote_endpoint_aging"></a> [remote\_endpoint\_aging](#input\_remote\_endpoint\_aging) | APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535. | `number` | `300` | no |
-| <a name="input_move_frequency"></a> [move\_frequency](#input\_move\_frequency) | APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. | `number` | `300` | no |
+| <a name="input_bounce_entry_aging"></a> [bounce\_entry\_aging](#input\_bounce\_entry\_aging) | APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535. Value 0 = infinite. | `number` | `630` | no |
+| <a name="input_local_endpoint_aging"></a> [local\_endpoint\_aging](#input\_local\_endpoint\_aging) | APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite. | `number` | `900` | no |
+| <a name="input_remote_endpoint_aging"></a> [remote\_endpoint\_aging](#input\_remote\_endpoint\_aging) | APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite. | `number` | `300` | no |
+| <a name="input_move_frequency"></a> [move\_frequency](#input\_move\_frequency) | APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. Value 0 = none. | `number` | `300` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-endpoint-retention-policy/examples/complete/.terraform-docs.yml
+++ b/modules/terraform-aci-endpoint-retention-policy/examples/complete/.terraform-docs.yml
@@ -1,0 +1,24 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Endpoint Retention Policy Example
+
+  To run this example you need to execute:
+
+  ```bash
+  $ terraform init
+  $ terraform plan
+  $ terraform apply
+  ```
+
+  Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+  ```hcl
+  {{ include "./main.tf" }}
+  ```
+
+output:
+  file: README.md
+  mode: replace

--- a/modules/terraform-aci-endpoint-retention-policy/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-retention-policy/examples/complete/README.md
@@ -13,15 +13,15 @@ Note that this example will create resources. Resources can be destroyed with `t
 
 ```hcl
 module "aci_end_point_retention_policy" {
-  source                = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
-  version               = ">= 0.9.4"
-  name                  = "ERP1"
-  descr                 = "Terraform"
-  hold_interval         = 6
-  bounce_entry_aging    = 630
-  local_endpoint_aging  = 900
-  remote_endpoint_aging = 300
-  move_frequency        = 256
+  source                         = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
+  version                        = ">= 0.9.4"
+  name                           = "ERP1"
+  descr                          = "Terraform"
+  hold_interval                  = 6
+  bounce_entry_aging_interval    = 630
+  local_endpoint_aging_interval  = 900
+  remote_endpoint_aging_interval = 300
+  move_frequency                 = 256
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-endpoint-retention-policy/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-retention-policy/examples/complete/README.md
@@ -1,0 +1,27 @@
+<!-- BEGIN_TF_DOCS -->
+# Endpoint Retention Policy Example
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+```hcl
+module "aci_end_point_retention_policy" {
+  source                = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
+  version               = ">= 0.9.4"
+  name                  = "ERP1"
+  descr                 = "Terraform"
+  hold_interval         = 6
+  bounce_entry_aging    = 630
+  local_endpoint_aging  = 900
+  remote_endpoint_aging = 300
+  move_frequency        = 256
+}
+```
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-endpoint-retention-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/examples/complete/main.tf
@@ -1,0 +1,11 @@
+module "aci_end_point_retention_policy" {
+  source                = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
+  version               = ">= 0.9.4"
+  name                  = "ERP1"
+  descr                 = "Terraform"
+  hold_interval         = 6
+  bounce_entry_aging    = 630
+  local_endpoint_aging  = 900
+  remote_endpoint_aging = 300
+  move_frequency        = 256
+}

--- a/modules/terraform-aci-endpoint-retention-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/examples/complete/main.tf
@@ -1,11 +1,11 @@
 module "aci_end_point_retention_policy" {
-  source                = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
-  version               = ">= 0.9.4"
-  name                  = "ERP1"
-  descr                 = "Terraform"
-  hold_interval         = 6
-  bounce_entry_aging    = 630
-  local_endpoint_aging  = 900
-  remote_endpoint_aging = 300
-  move_frequency        = 256
+  source                         = "netascode/nac-aci/aci//modules/terraform-aci-endpoint-retention-policy"
+  version                        = ">= 0.9.4"
+  name                           = "ERP1"
+  descr                          = "Terraform"
+  hold_interval                  = 6
+  bounce_entry_aging_interval    = 630
+  local_endpoint_aging_interval  = 900
+  remote_endpoint_aging_interval = 300
+  move_frequency                 = 256
 }

--- a/modules/terraform-aci-endpoint-retention-policy/examples/complete/versions.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/examples/complete/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/modules/terraform-aci-endpoint-retention-policy/examples/complete/versions.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.0.0"
+      version = ">= 2.15.0"
     }
   }
 }

--- a/modules/terraform-aci-endpoint-retention-policy/main.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/main.tf
@@ -5,9 +5,9 @@ resource "aci_rest_managed" "fvEpRetPol" {
     descr            = var.description
     name             = var.name
     holdIntvl        = var.hold_interval
-    bounceAgeIntvl   = var.bounce_entry_aging
-    localEpAgeIntvl  = var.local_endpoint_aging
-    remoteEpAgeIntvl = var.remote_endpoint_aging
-    moveFreq         = var.move_frequency
+    bounceAgeIntvl   = var.bounce_entry_aging == 0 ? "infinite" : var.bounce_entry_aging
+    localEpAgeIntvl  = var.local_endpoint_aging == 0 ? "infinite" : var.local_endpoint_aging
+    remoteEpAgeIntvl = var.remote_endpoint_aging == 0 ? "infinite" : var.remote_endpoint_aging
+    moveFreq         = var.move_frequency == 0 ? "none" : var.move_frequency
   }
 }

--- a/modules/terraform-aci-endpoint-retention-policy/main.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/main.tf
@@ -5,9 +5,9 @@ resource "aci_rest_managed" "fvEpRetPol" {
     descr            = var.description
     name             = var.name
     holdIntvl        = var.hold_interval
-    bounceAgeIntvl   = var.bounce_entry_aging == 0 ? "infinite" : var.bounce_entry_aging
-    localEpAgeIntvl  = var.local_endpoint_aging == 0 ? "infinite" : var.local_endpoint_aging
-    remoteEpAgeIntvl = var.remote_endpoint_aging == 0 ? "infinite" : var.remote_endpoint_aging
+    bounceAgeIntvl   = var.bounce_entry_aging_interval == 0 ? "infinite" : var.bounce_entry_aging_interval
+    localEpAgeIntvl  = var.local_endpoint_aging_interval == 0 ? "infinite" : var.local_endpoint_aging_interval
+    remoteEpAgeIntvl = var.remote_endpoint_aging_interval == 0 ? "infinite" : var.remote_endpoint_aging_interval
     moveFreq         = var.move_frequency == 0 ? "none" : var.move_frequency
   }
 }

--- a/modules/terraform-aci-endpoint-retention-policy/main.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/main.tf
@@ -1,0 +1,13 @@
+resource "aci_rest_managed" "fvEpRetPol" {
+  dn         = "uni/tn-${var.tenant}/epRPol-${var.name}"
+  class_name = "fvEpRetPol"
+  content = {
+    descr            = var.description
+    name             = var.name
+    holdIntvl        = var.hold_interval
+    bounceAgeIntvl   = var.bounce_entry_aging
+    localEpAgeIntvl  = var.local_endpoint_aging
+    remoteEpAgeIntvl = var.remote_endpoint_aging
+    moveFreq         = var.move_frequency
+  }
+}

--- a/modules/terraform-aci-endpoint-retention-policy/outputs.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/outputs.tf
@@ -1,0 +1,9 @@
+output "dn" {
+  value       = aci_rest_managed.fvEpRetPol.id
+  description = "Distinguished name of `fvEpRetPol` object."
+}
+
+output "name" {
+  value       = aci_rest_managed.fvEpRetPol.content.name
+  description = "Endpoint Retention policy name."
+}

--- a/modules/terraform-aci-endpoint-retention-policy/variables.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/variables.tf
@@ -46,7 +46,7 @@ variable "bounce_entry_aging" {
   default     = 630
 
   validation {
-    condition     = ( var.bounce_entry_aging >= 150 && var.bounce_entry_aging <= 65535 ) || var.bounce_entry_aging == 0
+    condition     = (var.bounce_entry_aging >= 150 && var.bounce_entry_aging <= 65535) || var.bounce_entry_aging == 0
     error_message = "Minimum value: 150. Maximum value: 65535. Value 0 = infinite."
   }
 }
@@ -56,7 +56,7 @@ variable "local_endpoint_aging" {
   default     = 900
 
   validation {
-    condition     = ( var.local_endpoint_aging >= 120 && var.local_endpoint_aging <= 65535 ) || var.local_endpoint_aging == 0
+    condition     = (var.local_endpoint_aging >= 120 && var.local_endpoint_aging <= 65535) || var.local_endpoint_aging == 0
     error_message = "Minimum value: 120. Maximum value: 65535."
   }
 }
@@ -66,7 +66,7 @@ variable "remote_endpoint_aging" {
   default     = 300
 
   validation {
-    condition     = ( var.remote_endpoint_aging >= 120 && var.remote_endpoint_aging <= 65535 ) || var.remote_endpoint_aging == 0
+    condition     = (var.remote_endpoint_aging >= 120 && var.remote_endpoint_aging <= 65535) || var.remote_endpoint_aging == 0
     error_message = "Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
   }
 }

--- a/modules/terraform-aci-endpoint-retention-policy/variables.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/variables.tf
@@ -1,0 +1,82 @@
+variable "tenant" {
+  description = "Tenant name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "name" {
+  description = "Endpoint Retention policy name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "description" {
+  description = "Description."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9\\!#$%()*,-./:;@ _{|}~?&+]{0,128}$", var.description))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, }`, `~`, `?`, `&`, `+`. Maximum characters: 128."
+  }
+}
+
+variable "hold_interval" {
+  description = "APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.hold_interval >= 5 && var.hold_interval <= 65535
+    error_message = "Minimum value: 5. Maximum value: 65535."
+  }
+}
+
+variable "bounce_entry_aging" {
+  description = "APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535."
+  type        = number
+  default     = 630
+
+  validation {
+    condition     = var.bounce_entry_aging >= 150 && var.bounce_entry_aging <= 65535
+    error_message = "Minimum value: 150. Maximum value: 65535."
+  }
+}
+variable "local_endpoint_aging" {
+  description = "APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535."
+  type        = number
+  default     = 900
+
+  validation {
+    condition     = var.local_endpoint_aging >= 120 && var.local_endpoint_aging <= 65535
+    error_message = "Minimum value: 120. Maximum value: 65535."
+  }
+}
+variable "remote_endpoint_aging" {
+  description = "APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.remote_endpoint_aging >= 120 && var.remote_endpoint_aging <= 65535
+    error_message = "Minimum value: 120. Maximum value: 65535."
+  }
+}
+variable "move_frequency" {
+  description = "APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.move_frequency >= 0 && var.move_frequency <= 65535
+    error_message = "Minimum value: 0. Maximum value: 65535."
+  }
+}

--- a/modules/terraform-aci-endpoint-retention-policy/variables.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/variables.tf
@@ -35,48 +35,48 @@ variable "hold_interval" {
   default     = 300
 
   validation {
-    condition     = var.hold_interval >= 5 && var.hold_interval <= 65535
+    condition     = (var.hold_interval >= 5 && var.hold_interval <= 65535)
     error_message = "Minimum value: 5. Maximum value: 65535."
   }
 }
 
 variable "bounce_entry_aging" {
-  description = "APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535."
+  description = "APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535. Value 0 = infinite."
   type        = number
   default     = 630
 
   validation {
-    condition     = var.bounce_entry_aging >= 150 && var.bounce_entry_aging <= 65535
-    error_message = "Minimum value: 150. Maximum value: 65535."
+    condition     = ( var.bounce_entry_aging >= 150 && var.bounce_entry_aging <= 65535 ) || var.bounce_entry_aging == 0
+    error_message = "Minimum value: 150. Maximum value: 65535. Value 0 = infinite."
   }
 }
 variable "local_endpoint_aging" {
-  description = "APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535."
+  description = "APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
   type        = number
   default     = 900
 
   validation {
-    condition     = var.local_endpoint_aging >= 120 && var.local_endpoint_aging <= 65535
+    condition     = ( var.local_endpoint_aging >= 120 && var.local_endpoint_aging <= 65535 ) || var.local_endpoint_aging == 0
     error_message = "Minimum value: 120. Maximum value: 65535."
   }
 }
 variable "remote_endpoint_aging" {
-  description = "APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535."
+  description = "APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
   type        = number
   default     = 300
 
   validation {
-    condition     = var.remote_endpoint_aging >= 120 && var.remote_endpoint_aging <= 65535
-    error_message = "Minimum value: 120. Maximum value: 65535."
+    condition     = ( var.remote_endpoint_aging >= 120 && var.remote_endpoint_aging <= 65535 ) || var.remote_endpoint_aging == 0
+    error_message = "Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
   }
 }
 variable "move_frequency" {
-  description = "APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535."
+  description = "APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. Value 0 = none."
   type        = number
   default     = 300
 
   validation {
     condition     = var.move_frequency >= 0 && var.move_frequency <= 65535
-    error_message = "Minimum value: 0. Maximum value: 65535."
+    error_message = "Minimum value: 0. Maximum value: 65535. Value 0 = none."
   }
 }

--- a/modules/terraform-aci-endpoint-retention-policy/variables.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/variables.tf
@@ -71,7 +71,7 @@ variable "remote_endpoint_aging" {
   }
 }
 variable "move_frequency" {
-  description = "APIC Endpoint Retention hold interval. Minimum value: 5. Maximum value: 65535. Value 0 = none."
+  description = "APIC Endpoint Retention move frequency. Minimum value: 5. Maximum value: 65535. Value 0 = none."
   type        = number
   default     = 300
 

--- a/modules/terraform-aci-endpoint-retention-policy/variables.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/variables.tf
@@ -40,33 +40,33 @@ variable "hold_interval" {
   }
 }
 
-variable "bounce_entry_aging" {
-  description = "APIC Endpoint Retention bounce entry aging. Minimum value: 150. Maximum value: 65535. Value 0 = infinite."
+variable "bounce_entry_aging_interval" {
+  description = "APIC Endpoint Retention bounce entry aging interval. Minimum value: 150. Maximum value: 65535. Value 0 = infinite."
   type        = number
   default     = 630
 
   validation {
-    condition     = (var.bounce_entry_aging >= 150 && var.bounce_entry_aging <= 65535) || var.bounce_entry_aging == 0
+    condition     = (var.bounce_entry_aging_interval >= 150 && var.bounce_entry_aging_interval <= 65535) || var.bounce_entry_aging_interval == 0
     error_message = "Minimum value: 150. Maximum value: 65535. Value 0 = infinite."
   }
 }
-variable "local_endpoint_aging" {
-  description = "APIC Endpoint Retention local endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
+variable "local_endpoint_aging_interval" {
+  description = "APIC Endpoint Retention local endpoint agin interval. Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
   type        = number
   default     = 900
 
   validation {
-    condition     = (var.local_endpoint_aging >= 120 && var.local_endpoint_aging <= 65535) || var.local_endpoint_aging == 0
+    condition     = (var.local_endpoint_aging_interval >= 120 && var.local_endpoint_aging_interval <= 65535) || var.local_endpoint_aging_interval == 0
     error_message = "Minimum value: 120. Maximum value: 65535."
   }
 }
-variable "remote_endpoint_aging" {
-  description = "APIC Endpoint Retention remote endpoint aging. Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
+variable "remote_endpoint_aging_interval" {
+  description = "APIC Endpoint Retention remote endpoint aging interval. Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
   type        = number
   default     = 300
 
   validation {
-    condition     = (var.remote_endpoint_aging >= 120 && var.remote_endpoint_aging <= 65535) || var.remote_endpoint_aging == 0
+    condition     = (var.remote_endpoint_aging_interval >= 120 && var.remote_endpoint_aging_interval <= 65535) || var.remote_endpoint_aging_interval == 0
     error_message = "Minimum value: 120. Maximum value: 65535. Value 0 = infinite."
   }
 }

--- a/modules/terraform-aci-endpoint-retention-policy/versions.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/modules/terraform-aci-endpoint-retention-policy/versions.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/versions.tf
@@ -1,11 +1,10 @@
-
 terraform {
   required_version = ">= 1.3.0"
 
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.0.0"
+      version = ">= 2.15.0"
     }
   }
 }

--- a/modules/terraform-aci-vrf/README.md
+++ b/modules/terraform-aci-vrf/README.md
@@ -22,6 +22,7 @@ module "aci_vrf" {
   data_plane_learning                    = false
   preferred_group                        = true
   transit_route_tag_policy               = "TRP1"
+  endpoint_retention_policy              = "ERP1"
   bgp_timer_policy                       = "BGP1"
   bgp_ipv4_address_family_context_policy = "BGP_AF_IPV4"
   bgp_ipv6_address_family_context_policy = "BGP_AF_IPV6"
@@ -187,6 +188,7 @@ module "aci_vrf" {
 | <a name="input_leaked_internal_prefixes"></a> [leaked\_internal\_prefixes](#input\_leaked\_internal\_prefixes) | List of leaked internal prefixes. Default value `public`: false. | <pre>list(object({<br/>    prefix = string<br/>    public = optional(bool, false)<br/>    destinations = optional(list(object({<br/>      description = optional(string, "")<br/>      tenant      = string<br/>      vrf         = string<br/>      public      = optional(bool)<br/>    })), [])<br/>  }))</pre> | `[]` | no |
 | <a name="input_leaked_external_prefixes"></a> [leaked\_external\_prefixes](#input\_leaked\_external\_prefixes) | List of leaked external prefixes. | <pre>list(object({<br/>    prefix             = string<br/>    from_prefix_length = optional(number)<br/>    to_prefix_length   = optional(number)<br/>    destinations = optional(list(object({<br/>      description = optional(string, "")<br/>      tenant      = string<br/>      vrf         = string<br/>    })), [])<br/>  }))</pre> | `[]` | no |
 | <a name="input_route_summarization_policies"></a> [route\_summarization\_policies](#input\_route\_summarization\_policies) | List of route summarization policies. | <pre>list(object({<br/>    name = string<br/>    nodes = optional(list(object({<br/>      id  = number<br/>      pod = optional(number, 1)<br/>    })), [])<br/>    subnets = optional(list(object({<br/>      prefix                         = string<br/>      bgp_route_summarization_policy = optional(string, null)<br/>    })), [])<br/>  }))</pre> | `[]` | no |
+| <a name="input_endpoint_retention_policy"></a> [endpoint\_retention\_policy](#input\_endpoint\_retention\_policy) | Endpoint Retention Policy. | `string` | `""` | no |
 
 ## Outputs
 
@@ -211,6 +213,7 @@ module "aci_vrf" {
 | [aci_rest_managed.fvRsBgpCtxPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtxToBgpCtxAfPol_ipv4](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtxToBgpCtxAfPol_ipv6](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvRsCtxToEpRet](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtxToExtRouteTagPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtxToOspfCtxPol_ipv4](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvRsCtxToOspfCtxPol_ipv6](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-vrf/examples/complete/README.md
+++ b/modules/terraform-aci-vrf/examples/complete/README.md
@@ -25,6 +25,7 @@ module "aci_vrf" {
   data_plane_learning                    = false
   preferred_group                        = true
   transit_route_tag_policy               = "TRP1"
+  endpoint_retention_policy              = "ERP1"
   bgp_timer_policy                       = "BGP1"
   bgp_ipv4_address_family_context_policy = "BGP_AF_IPV4"
   bgp_ipv6_address_family_context_policy = "BGP_AF_IPV6"

--- a/modules/terraform-aci-vrf/examples/complete/main.tf
+++ b/modules/terraform-aci-vrf/examples/complete/main.tf
@@ -11,6 +11,7 @@ module "aci_vrf" {
   data_plane_learning                    = false
   preferred_group                        = true
   transit_route_tag_policy               = "TRP1"
+  endpoint_retention_policy              = "ERP1"
   bgp_timer_policy                       = "BGP1"
   bgp_ipv4_address_family_context_policy = "BGP_AF_IPV4"
   bgp_ipv6_address_family_context_policy = "BGP_AF_IPV6"

--- a/modules/terraform-aci-vrf/main.tf
+++ b/modules/terraform-aci-vrf/main.tf
@@ -561,3 +561,12 @@ resource "aci_rest_managed" "fvRtSummSubnet" {
     }
   }
 }
+
+resource "aci_rest_managed" "fvRsCtxToEpRet" {
+  count      = var.endpoint_retention_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.fvCtx.dn}/rsctxToEpRet"
+  class_name = "fvRsCtxToEpRet"
+  content = {
+    tnFvEpRetPolName = var.endpoint_retention_policy
+  }
+}

--- a/modules/terraform-aci-vrf/variables.tf
+++ b/modules/terraform-aci-vrf/variables.tf
@@ -644,3 +644,14 @@ variable "route_summarization_policies" {
     error_message = "`subnets.bgp_route_summarization_policy`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
 }
+
+variable "endpoint_retention_policy" {
+  description = "Endpoint Retention Policy."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.endpoint_retention_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}


### PR DESCRIPTION
Added support for Endpoint Retention Policy under:
Tenant -> Policies -> Protocol -> End Point Retention

Policy is can be applied under:
-BD
-VRF

Feature is supported on:
-4.x
-5.x
-6.x