### PR TITLE
ignoreIgpMetric added to bgp_best_path_policy. Fix for issue 557.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Add support for global SR MPLS configuration
 - Add support for multicast ARP drop for BD
 - Add support for BGP route summarization at the VRF level
-- Add support for access MACsec Policies.
+- Add support for access MACsec Policies
 
 ## 0.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Add support for global SR MPLS configuration
 - Add support for multicast ARP drop for BD
 - Add support for BGP route summarization at the VRF level
-- Add support for access MACsec Policies
+- Add support for access MACsec Policies.
 
 ## 0.9.1
 

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -2657,11 +2657,12 @@ locals {
 module "aci_bgp_best_path_policy" {
   source = "./modules/terraform-aci-bgp-best-path-policy"
 
-  for_each     = { for pol in local.bgp_best_path_policies : pol.key => pol if local.modules.aci_bgp_best_path_policy && var.manage_tenants }
-  tenant       = each.value.tenant
-  name         = each.value.name
-  description  = each.value.description
-  control_type = each.value.control_type
+  for_each                = { for pol in local.bgp_best_path_policies : pol.key => pol if local.modules.aci_bgp_best_path_policy && var.manage_tenants }
+  tenant                  = each.value.tenant
+  name                    = each.value.name
+  description             = each.value.description
+  as_path_multipath_relax = each.value.as_path_multipath_relax
+  ignore_igp_metric       = each.value.ignore_igp_metric
 
   depends_on = [
     module.aci_tenant,

--- a/modules/terraform-aci-bgp-best-path-policy/README.md
+++ b/modules/terraform-aci-bgp-best-path-policy/README.md
@@ -13,10 +13,11 @@ module "aci_bgp_best_path_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-bgp-best-path-policy"
   version = ">= 0.8.0"
 
-  name         = "ABC"
-  tenant       = "TEN1"
-  description  = "My BGP Best Path Policy"
-  control_type = "multi-path-relax"
+  name                    = "ABC"
+  tenant                  = "TEN1"
+  description             = "My BGP Best Path Policy"
+  as_path_multipath_relax = true
+  ignore_igp_metric       = false
 }
 ```
 

--- a/modules/terraform-aci-bgp-best-path-policy/README.md
+++ b/modules/terraform-aci-bgp-best-path-policy/README.md
@@ -40,7 +40,8 @@ module "aci_bgp_best_path_policy" {
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | Tenant name. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | BGP best path policy name. | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | BGP best path policy description. | `string` | `""` | no |
-| <a name="input_control_type"></a> [control\_type](#input\_control\_type) | BGP best path policy control type. Allowed value: `multi-path-relax`. | `string` | `""` | no |
+| <a name="input_as_path_multipath_relax"></a> [as\_path\_multipath\_relax](#input\_as\_path\_multipath\_relax) | Flag to Relax AS-Path restriction. | `bool` | `false` | no |
+| <a name="input_ignore_igp_metric"></a> [ignore\_igp\_metric](#input\_ignore\_igp\_metric) | Flag to Ignore IGP metric. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-bgp-best-path-policy/examples/complete/README.md
+++ b/modules/terraform-aci-bgp-best-path-policy/examples/complete/README.md
@@ -16,10 +16,11 @@ module "aci_bgp_best_path_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-bgp-best-path-policy"
   version = ">= 0.8.0"
 
-  name         = "ABC"
-  tenant       = "TEN1"
-  description  = "My BGP Best Path Policy"
-  control_type = "multi-path-relax"
+  name                    = "ABC"
+  tenant                  = "TEN1"
+  description             = "My BGP Best Path Policy"
+  as_path_multipath_relax = true
+  ignore_igp_metric       = false
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-bgp-best-path-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-bgp-best-path-policy/examples/complete/main.tf
@@ -2,8 +2,9 @@ module "aci_bgp_best_path_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-bgp-best-path-policy"
   version = ">= 0.8.0"
 
-  name         = "ABC"
-  tenant       = "TEN1"
-  description  = "My BGP Best Path Policy"
-  control_type = "multi-path-relax"
+  name                    = "ABC"
+  tenant                  = "TEN1"
+  description             = "My BGP Best Path Policy"
+  as_path_multipath_relax = true
+  ignore_igp_metric       = false
 }

--- a/modules/terraform-aci-bgp-best-path-policy/main.tf
+++ b/modules/terraform-aci-bgp-best-path-policy/main.tf
@@ -4,6 +4,6 @@ resource "aci_rest_managed" "bgpBestPathCtrlPol" {
   content = {
     name  = var.name
     descr = var.description
-    ctrl  = var.control_type == "multi-path-relax" ? "asPathMultipathRelax" : ""
+    ctrl  = join(",", concat(var.as_path_multipath_relax == true ? ["asPathMultipathRelax"] : [], var.ignore_igp_metric == true ? ["ignoreIgpMetric"] : []))
   }
 }

--- a/modules/terraform-aci-bgp-best-path-policy/variables.tf
+++ b/modules/terraform-aci-bgp-best-path-policy/variables.tf
@@ -29,13 +29,15 @@ variable "description" {
   }
 }
 
-variable "control_type" {
-  description = "BGP best path policy control type. Allowed value: `multi-path-relax`."
-  type        = string
-  default     = ""
+variable "as_path_multipath_relax" {
+  description = "Flag to Relax AS-Path restriction."
+  type        = bool
+  default     = false
 
-  validation {
-    condition     = var.control_type == "" || var.control_type == "multi-path-relax"
-    error_message = "Allowed value: `multi-path-relax`."
-  }
+}
+
+variable "ignore_igp_metric" {
+  description = "Flag to Ignore IGP metric."
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
This is a potential solution for Issue #557.

**Note: ignoreigpMetric feature is present only in ACI 6.1**