### PR TITLE
updated vzIn/vzOut If condiiton

### DIFF
--- a/modules/terraform-aci-contract/main.tf
+++ b/modules/terraform-aci-contract/main.tf
@@ -93,7 +93,7 @@ resource "aci_rest_managed" "vzRsSubjGraphAtt" {
 }
 
 resource "aci_rest_managed" "vzInTerm" {
-  for_each   = { for subj in var.subjects : subj.name => subj if length(subj.filters) == 0 && length(subj.consumer_to_provider_filters) != 0 }
+  for_each   = { for subj in var.subjects : subj.name => subj if length(subj.filters) == 0 && length(subj.provider_to_consumer_filters) + length(subj.consumer_to_provider_filters) != 0 }
   dn         = "${aci_rest_managed.vzSubj[each.key].dn}/intmnl"
   class_name = "vzInTerm"
   content = {
@@ -103,7 +103,7 @@ resource "aci_rest_managed" "vzInTerm" {
 }
 
 resource "aci_rest_managed" "vzOutTerm" {
-  for_each   = { for subj in var.subjects : subj.name => subj if length(subj.filters) == 0 && length(subj.provider_to_consumer_filters) != 0 }
+  for_each   = { for subj in var.subjects : subj.name => subj if length(subj.filters) == 0 && length(subj.provider_to_consumer_filters) + length(subj.consumer_to_provider_filters) != 0 }
   dn         = "${aci_rest_managed.vzSubj[each.key].dn}/outtmnl"
   class_name = "vzOutTerm"
   content = {


### PR DESCRIPTION
updated condition for vzInTerm and vzOutTerm, to keep state of those objects if any uni-dir filter is provided.
We need to keep state of both together because:
-if we won't keep state of both objects in tf state and create only one side of subject eg. vzInTerm
-then we delete unidir config which is only vzInTerm
-then we create bidirectional filters
Due to managing only 1 object, vzOutTerm persists while contract is bidirectional.