### PR TITLE
Ip sla policy

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -982,7 +982,7 @@ locals {
         for np in try(l3out.node_profiles, []) : {
           key                       = format("%s/%s/%s", tenant.name, l3out.name, np.name)
           tenant                    = tenant.name
-          l3out                     = l3out.name
+          l3out                     = "${l3out.name}${local.defaults.apic.tenants.l3outs.name_suffix}"
           name                      = "${np.name}${local.defaults.apic.tenants.l3outs.node_profiles.name_suffix}"
           multipod                  = try(l3out.multipod, local.defaults.apic.tenants.l3outs.multipod)
           remote_leaf               = try(l3out.remote_leaf, local.defaults.apic.tenants.l3outs.remote_leaf)
@@ -1075,8 +1075,8 @@ locals {
       for l3out in try(tenant.l3outs, []) : {
         key                       = format("%s/%s", tenant.name, l3out.name)
         tenant                    = tenant.name
-        l3out                     = l3out.name
-        name                      = l3out.name
+        l3out                     = "${l3out.name}${local.defaults.apic.tenants.l3outs.name_suffix}"
+        name                      = "${l3out.name}${local.defaults.apic.tenants.l3outs.name_suffix}"
         multipod                  = try(l3out.multipod, local.defaults.apic.tenants.l3outs.multipod)
         remote_leaf               = try(l3out.remote_leaf, local.defaults.apic.tenants.l3outs.remote_leaf)
         bgp_protocol_profile_name = try(l3out.bgp.name, "")

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -1003,13 +1003,12 @@ locals {
               bfd         = try(sr.bfd, local.defaults.apic.tenants.l3outs.node_profiles.nodes.static_routes.bfd)
               track_list  = try(sr.track_list, null)
               next_hops = [for nh in try(sr.next_hops, []) : {
-                ip                        = nh.ip
-                description               = try(nh.description, "")
-                preference                = try(nh.preference, local.defaults.apic.tenants.l3outs.node_profiles.nodes.static_routes.next_hops.preference)
-                type                      = try(nh.type, local.defaults.apic.tenants.l3outs.node_profiles.nodes.static_routes.next_hops.type)
-                ip_sla_policy             = try("${nh.ip_sla_policy}${local.defaults.apic.tenants.policies.ip_sla_policies.name_suffix}", null)
-                track_list                = try("${nh.track_list}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
-                auto_generated_track_list = try("${l3out.vrf}${local.defaults.apic.tenants.vrfs.name_suffix}_${nh.ip}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
+                ip            = nh.ip
+                description   = try(nh.description, "")
+                preference    = try(nh.preference, local.defaults.apic.tenants.l3outs.node_profiles.nodes.static_routes.next_hops.preference)
+                type          = try(nh.type, local.defaults.apic.tenants.l3outs.node_profiles.nodes.static_routes.next_hops.type)
+                ip_sla_policy = try("${nh.ip_sla_policy}${local.defaults.apic.tenants.policies.ip_sla_policies.name_suffix}", null)
+                track_list    = try("${nh.track_list}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
               }]
             }]
           }]
@@ -1097,13 +1096,12 @@ locals {
             bfd         = try(sr.bfd, local.defaults.apic.tenants.l3outs.node_profiles.nodes.static_routes.bfd)
             track_list  = try(sr.track_list, null)
             next_hops = [for nh in try(sr.next_hops, []) : {
-              ip                        = nh.ip
-              description               = try(nh.description, "")
-              preference                = try(nh.preference, local.defaults.apic.tenants.l3outs.nodes.static_routes.next_hops.preference)
-              type                      = try(nh.type, local.defaults.apic.tenants.l3outs.nodes.static_routes.next_hops.type)
-              ip_sla_policy             = try("${nh.ip_sla_policy}${local.defaults.apic.tenants.policies.ip_sla_policies.name_suffix}", null)
-              track_list                = try("${nh.track_list}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
-              auto_generated_track_list = try("${l3out.vrf}_${nh.ip}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
+              ip            = nh.ip
+              description   = try(nh.description, "")
+              preference    = try(nh.preference, local.defaults.apic.tenants.l3outs.nodes.static_routes.next_hops.preference)
+              type          = try(nh.type, local.defaults.apic.tenants.l3outs.nodes.static_routes.next_hops.type)
+              ip_sla_policy = try("${nh.ip_sla_policy}${local.defaults.apic.tenants.policies.ip_sla_policies.name_suffix}", null)
+              track_list    = try("${nh.track_list}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
             }]
           }]
         }]

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -1008,7 +1008,7 @@ locals {
                 preference    = try(nh.preference, local.defaults.apic.tenants.l3outs.node_profiles.nodes.static_routes.next_hops.preference)
                 type          = try(nh.type, local.defaults.apic.tenants.l3outs.node_profiles.nodes.static_routes.next_hops.type)
                 ip_sla_policy = try("${nh.ip_sla_policy}${local.defaults.apic.tenants.policies.ip_sla_policies.name_suffix}", null)
-                track_list    = try("${nh.track_list}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
+                track_list    = try(try(nh.ip_sla_policy, null) != null ? "${l3out.vrf}${local.defaults.apic.tenants.vrfs.name_suffix}_${nh.ip}${local.defaults.apic.tenants.policies.track_lists.name_suffix}" : "${nh.track_list}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
               }]
             }]
           }]
@@ -1101,7 +1101,7 @@ locals {
               preference    = try(nh.preference, local.defaults.apic.tenants.l3outs.nodes.static_routes.next_hops.preference)
               type          = try(nh.type, local.defaults.apic.tenants.l3outs.nodes.static_routes.next_hops.type)
               ip_sla_policy = try("${nh.ip_sla_policy}${local.defaults.apic.tenants.policies.ip_sla_policies.name_suffix}", null)
-              track_list    = try("${nh.track_list}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
+              track_list    = try(try(nh.ip_sla_policy, null) != null ? "${l3out.vrf}${local.defaults.apic.tenants.vrfs.name_suffix}_${nh.ip}${local.defaults.apic.tenants.policies.track_lists.name_suffix}" : "${nh.track_list}${local.defaults.apic.tenants.policies.track_lists.name_suffix}", null)
             }]
           }]
         }]

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1468,10 +1468,10 @@ defaults:
         track_lists:
           name_suffix: ""
           type: percentage
-          percentage_up: 0
-          percentage_down: 1
-          weight_up: 0
-          weight_down: 1
+          percentage_up: 1
+          percentage_down: 0
+          weight_up: 1
+          weight_down: 0
         track_members:
           name_suffix: ""
         endpoint_mac_tags:

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1472,6 +1472,8 @@ defaults:
           percentage_down: 1
           weight_up: 0
           weight_down: 1
+        track_members:
+          name_suffix: ""
         endpoint_mac_tags:
           bridge_domain: all
         endpoint_retention_policies:

--- a/modules/terraform-aci-l3out-node-profile/README.md
+++ b/modules/terraform-aci-l3out-node-profile/README.md
@@ -36,7 +36,16 @@ module "aci_l3out_node_profile" {
         description = "Next Hop Description"
         preference  = 10
         type        = "prefix"
-      }]
+        track_list  = "TRACK_LIST1"
+        },
+        {
+          ip            = "5.5.5.5"
+          description   = "Next Hop Description"
+          preference    = 10
+          type          = "prefix"
+          ip_sla_policy = "IP_SLA_POLICY1"
+        }
+      ]
     }]
   }]
   bgp_peers = [{
@@ -90,7 +99,7 @@ module "aci_l3out_node_profile" {
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | Tenant name. | `string` | n/a | yes |
 | <a name="input_l3out"></a> [l3out](#input\_l3out) | L3out name. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Node profile name. | `string` | n/a | yes |
-| <a name="input_nodes"></a> [nodes](#input\_nodes) | List of nodes. Allowed values `node_id`: 1-4000. Allowed values `pod_id`: 1-255. Default value `pod_id`: 1. Default value `router_id_as_loopback`: true. Allowed values `static_routes.preference`: 1-255. Default value `static_routes.preference`: 1. Default value `static_routes.bfd`: false. Allowed values `static_routes.next_hops.preference`: 0-255. Default value `static_routes.next_hops.preference`: 1. Choices `type`: `prefix`, `none`. Default value `type`: `prefix`. | <pre>list(object({<br/>    node_id                 = number<br/>    pod_id                  = optional(number, 1)<br/>    router_id               = string<br/>    router_id_as_loopback   = optional(bool, true)<br/>    loopbacks               = optional(list(string))<br/>    mpls_transport_loopback = optional(string)<br/>    segment_id              = optional(number)<br/>    static_routes = optional(list(object({<br/>      prefix      = string<br/>      description = optional(string, "")<br/>      preference  = optional(number, 1)<br/>      bfd         = optional(bool, false)<br/>      track_list  = optional(string)<br/>      next_hops = optional(list(object({<br/>        ip          = string<br/>        description = optional(string, "")<br/>        preference  = optional(number, 1)<br/>        type        = optional(string, "prefix")<br/>      })), [])<br/>    })), [])<br/>  }))</pre> | `[]` | no |
+| <a name="input_nodes"></a> [nodes](#input\_nodes) | List of nodes. Allowed values `node_id`: 1-4000. Allowed values `pod_id`: 1-255. Default value `pod_id`: 1. Default value `router_id_as_loopback`: true. Allowed values `static_routes.preference`: 1-255. Default value `static_routes.preference`: 1. Default value `static_routes.bfd`: false. Allowed values `static_routes.next_hops.preference`: 0-255. Default value `static_routes.next_hops.preference`: 1. Choices `type`: `prefix`, `none`. Default value `type`: `prefix`. | <pre>list(object({<br/>    node_id                 = number<br/>    pod_id                  = optional(number, 1)<br/>    router_id               = string<br/>    router_id_as_loopback   = optional(bool, true)<br/>    loopbacks               = optional(list(string))<br/>    mpls_transport_loopback = optional(string)<br/>    segment_id              = optional(number)<br/>    static_routes = optional(list(object({<br/>      prefix      = string<br/>      description = optional(string, "")<br/>      preference  = optional(number, 1)<br/>      bfd         = optional(bool, false)<br/>      track_list  = optional(string)<br/>      next_hops = optional(list(object({<br/>        ip            = string<br/>        description   = optional(string, "")<br/>        preference    = optional(number, 1)<br/>        type          = optional(string, "prefix")<br/>        ip_sla_policy = optional(string)<br/>        track_list    = optional(string)<br/>      })), [])<br/>    })), [])<br/>  }))</pre> | `[]` | no |
 | <a name="input_bgp_peers"></a> [bgp\_peers](#input\_bgp\_peers) | List of BGP peers. Allowed values `remote_as`: 0-4294967295. Default value `allow_self_as`: false. Default value `as_override`: false. Default value `disable_peer_as_check`: false. Default value `next_hop_self`: false. Default value `send_community`: false. Default value `send_ext_community`: false. Allowed values `allowed_self_as_count`: 1-10. Default value `allowed_self_as_count`: 3. Default value `bfd`: false. Default value `disable_connected_check`: false. Allowed values `ttl`: 1-255. Default value `ttl`: 1. Allowed values `weight`: 0-65535. Default value `weight`: 0. Default value `remove_all_private_as`: false. Default value `remove_private_as`: false. Default value `replace_private_as_with_local_as`: false. Default value `unicast_address_family`: true. Default value `multicast_address_family`: true. Default value `admin_state`: true. Allowed values `local_as`: 0-4294967295. Choices `as_propagate`: `none`, `no-prepend`, `replace-as`, `dual-as`. Default value `as_propagate`: `none`. | <pre>list(object({<br/>    ip                               = string<br/>    remote_as                        = string<br/>    description                      = optional(string, "")<br/>    allow_self_as                    = optional(bool, false)<br/>    as_override                      = optional(bool, false)<br/>    disable_peer_as_check            = optional(bool, false)<br/>    next_hop_self                    = optional(bool, false)<br/>    send_community                   = optional(bool, false)<br/>    send_ext_community               = optional(bool, false)<br/>    password                         = optional(string)<br/>    allowed_self_as_count            = optional(number, 3)<br/>    bfd                              = optional(bool, false)<br/>    disable_connected_check          = optional(bool, false)<br/>    ttl                              = optional(number, 1)<br/>    weight                           = optional(number, 0)<br/>    remove_all_private_as            = optional(bool, false)<br/>    remove_private_as                = optional(bool, false)<br/>    replace_private_as_with_local_as = optional(bool, false)<br/>    unicast_address_family           = optional(bool, true)<br/>    multicast_address_family         = optional(bool, true)<br/>    admin_state                      = optional(bool, true)<br/>    local_as                         = optional(number)<br/>    as_propagate                     = optional(string, "none")<br/>    peer_prefix_policy               = optional(string)<br/>    export_route_control             = optional(string)<br/>    import_route_control             = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_multipod"></a> [multipod](#input\_multipod) | Multipod L3out flag. | `bool` | `false` | no |
 | <a name="input_remote_leaf"></a> [remote\_leaf](#input\_remote\_leaf) | Remote leaf L3out flag. | `bool` | `false` | no |
@@ -101,6 +110,7 @@ module "aci_l3out_node_profile" {
 | <a name="input_bgp_protocol_profile_name"></a> [bgp\_protocol\_profile\_name](#input\_bgp\_protocol\_profile\_name) | BGP Protocol Name. | `string` | `""` | no |
 | <a name="input_bgp_timer_policy"></a> [bgp\_timer\_policy](#input\_bgp\_timer\_policy) | Node Profile's BGP Timer Policy | `string` | `""` | no |
 | <a name="input_bgp_as_path_policy"></a> [bgp\_as\_path\_policy](#input\_bgp\_as\_path\_policy) | Node Profile's BGP AS-Path Policy | `string` | `""` | no |
+| <a name="input_vrf"></a> [vrf](#input\_vrf) | VRF name. | `string` | `null` | no |
 
 ## Outputs
 
@@ -130,6 +140,8 @@ module "aci_l3out_node_profile" {
 | [aci_rest_managed.bgpRsPeerToProfile_import](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.ipNexthopP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.ipRouteP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.ipRsNHTrackMember](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.ipRsNexthopRouteTrack](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.ipRsRouteTrack](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extInfraNodeP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.l3extLNodeP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-l3out-node-profile/examples/complete/README.md
+++ b/modules/terraform-aci-l3out-node-profile/examples/complete/README.md
@@ -39,7 +39,16 @@ module "aci_l3out_node_profile" {
         description = "Next Hop Description"
         preference  = 10
         type        = "prefix"
-      }]
+        track_list  = "TRACK_LIST1"
+        },
+        {
+          ip            = "5.5.5.5"
+          description   = "Next Hop Description"
+          preference    = 10
+          type          = "prefix"
+          ip_sla_policy = "IP_SLA_POLICY1"
+        }
+      ]
     }]
   }]
   bgp_peers = [{

--- a/modules/terraform-aci-l3out-node-profile/examples/complete/main.tf
+++ b/modules/terraform-aci-l3out-node-profile/examples/complete/main.tf
@@ -25,7 +25,16 @@ module "aci_l3out_node_profile" {
         description = "Next Hop Description"
         preference  = 10
         type        = "prefix"
-      }]
+        track_list  = "TRACK_LIST1"
+        },
+        {
+          ip            = "5.5.5.5"
+          description   = "Next Hop Description"
+          preference    = 10
+          type          = "prefix"
+          ip_sla_policy = "IP_SLA_POLICY1"
+        }
+      ]
     }]
   }]
   bgp_peers = [{

--- a/modules/terraform-aci-l3out-node-profile/main.tf
+++ b/modules/terraform-aci-l3out-node-profile/main.tf
@@ -301,7 +301,7 @@ resource "aci_rest_managed" "ipRsNexthopRouteTrack" {
   dn         = "${aci_rest_managed.ipRouteP[each.value.static_route].dn}/nh-[${each.value.ip}]/rsNexthopRouteTrack"
   class_name = "ipRsNexthopRouteTrack"
   content = {
-    tDn = format("%s%s", "uni/tn-${var.tenant}/tracklist-", each.value.ip_sla_policy != null ? "${var.vrf}_${each.value.ip}" : "${each.value.track_list}")
+    tDn = "uni/tn-${var.tenant}/tracklist-${each.value.track_list}"
   }
 }
 
@@ -310,6 +310,6 @@ resource "aci_rest_managed" "ipRsNHTrackMember" {
   dn         = "${aci_rest_managed.ipRouteP[each.value.static_route].dn}/nh-[${each.value.ip}]/rsNHTrackMember"
   class_name = "ipRsNHTrackMember"
   content = {
-    tDn = "uni/tn-${var.tenant}/trackmember-${var.vrf}_${each.value.ip}"
+    tDn = "uni/tn-${var.tenant}/trackmember-${each.value.track_list}"
   }
 }

--- a/modules/terraform-aci-l3out-node-profile/main.tf
+++ b/modules/terraform-aci-l3out-node-profile/main.tf
@@ -20,11 +20,13 @@ locals {
         for nh in coalesce(sr.next_hops, []) : {
           key = "${node.node_id}/${sr.prefix}/${nh.ip}"
           value = {
-            static_route = "${node.node_id}/${sr.prefix}"
-            ip           = nh.ip
-            description  = nh.description
-            preference   = nh.preference == 0 ? "unspecified" : nh.preference
-            type         = nh.type
+            static_route  = "${node.node_id}/${sr.prefix}"
+            ip            = nh.ip
+            description   = nh.description
+            preference    = nh.preference == 0 ? "unspecified" : nh.preference
+            type          = nh.type
+            ip_sla_policy = nh.ip_sla_policy
+            track_list    = nh.track_list
           }
         }
       ]
@@ -291,5 +293,23 @@ resource "aci_rest_managed" "bgpRsBestPathCtrlPol" {
   class_name = "bgpRsBestPathCtrlPol"
   content = {
     tnBgpBestPathCtrlPolName = var.bgp_as_path_policy
+  }
+}
+
+resource "aci_rest_managed" "ipRsNexthopRouteTrack" {
+  for_each   = { for next_hop in local.next_hops : next_hop.key => next_hop.value if next_hop.value.ip_sla_policy != null || next_hop.value.track_list != null }
+  dn         = "${aci_rest_managed.ipRouteP[each.value.static_route].dn}/nh-[${each.value.ip}]/rsNexthopRouteTrack"
+  class_name = "ipRsNexthopRouteTrack"
+  content = {
+    tDn = format("%s%s", "uni/tn-${var.tenant}/tracklist-", each.value.ip_sla_policy != null ? "${var.vrf}_${each.value.ip}" : "${each.value.track_list}")
+  }
+}
+
+resource "aci_rest_managed" "ipRsNHTrackMember" {
+  for_each   = { for next_hop in local.next_hops : next_hop.key => next_hop.value if next_hop.value.ip_sla_policy != null }
+  dn         = "${aci_rest_managed.ipRouteP[each.value.static_route].dn}/nh-[${each.value.ip}]/rsNHTrackMember"
+  class_name = "ipRsNHTrackMember"
+  content = {
+    tDn = "uni/tn-${var.tenant}/trackmember-${var.vrf}_${each.value.ip}"
   }
 }

--- a/modules/terraform-aci-l3out-node-profile/variables.tf
+++ b/modules/terraform-aci-l3out-node-profile/variables.tf
@@ -111,6 +111,7 @@ variable "nodes" {
     ]))
     error_message = "`static_routes.next_hops.ip_sla_policy`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }
+
 }
 
 variable "bgp_peers" {

--- a/modules/terraform-aci-l3out-node-profile/variables.tf
+++ b/modules/terraform-aci-l3out-node-profile/variables.tf
@@ -107,7 +107,7 @@ variable "nodes" {
 
   validation {
     condition = alltrue(flatten([
-      for n in var.nodes : [for s in coalesce(n.static_routes, []) : [for nh in coalesce(s.next_hops, []) : nh.track_list == null || can(regex("^[a-zA-Z0-9_.:-]{0,64}$", nh.ip_sla_policy))]]
+      for n in var.nodes : [for s in coalesce(n.static_routes, []) : [for nh in coalesce(s.next_hops, []) : nh.ip_sla_policy == null || can(regex("^[a-zA-Z0-9_.:-]{0,64}$", nh.ip_sla_policy))]]
     ]))
     error_message = "`static_routes.next_hops.ip_sla_policy`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
   }


### PR DESCRIPTION
PR Solves 4 issues:
1. it is not possible to create TL with default values because UP and DOWN values are 0. UP values must be higher than DOWN as per APIC validation.
2. Track_member dependency over node_profiles is removed as it forces Terraform to create Node Profile which has reference to TrackList. Perfect case scenario would be to create: L3out -> Track Member -> Track List -> L3out Node Profile.
3. Added support for attaching ip_sla_policy & track_list under: l3out -> node_profiles -> node -> static_route -> next_hop and auto generated node_profiles: l3out -> node -> static_route -> next_hop 
4. Added support to auto generate Track Member, Track List, Track List -> TrackMember refference, Track Member -> IP SLA Policyv reference, whenever ip_sla_policy is attached under next_hop. As per APIC example, default name for objects is vrf.name+"_"+next_hop.ip

Other Issues:
6. Feature supports name_suffix for IP_SLA_Policy, Track_list and Track_Member. However, it doesn't work for L3out since node_profiles and interface_profiles L3out value doesn't apply name_suffix and as result it breaks references between profiles and l3outs. Functionality is broken and needs to be fixed.