### PR TITLE
Add new "Leaf Fabric Port Policy Group" feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,6 +384,9 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+#Mac Book DS_Store
+.DS_Store
+
 # End of https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 
 # vsCode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -338,6 +338,13 @@ repos:
             "./modules/terraform-aci-fabric-leaf-switch-policy-group/examples/complete",
           ]
       - id: terraform-docs-system
+        args: ["./modules/terraform-aci-fabric-leaf-interface-policy-group"]
+      - id: terraform-docs-system
+        args:
+          [
+            "./modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete",
+          ]
+      - id: terraform-docs-system
         args: ["./modules/terraform-aci-fabric-leaf-switch-profile"]
       - id: terraform-docs-system
         args:

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Additional example repositories:
 | <a name="module_aci_fabric_isis_bfd"></a> [aci\_fabric\_isis\_bfd](#module\_aci\_fabric\_isis\_bfd) | ./modules/terraform-aci-fabric-isis-bfd | n/a |
 | <a name="module_aci_fabric_isis_policy"></a> [aci\_fabric\_isis\_policy](#module\_aci\_fabric\_isis\_policy) | ./modules/terraform-aci-fabric-isis-policy | n/a |
 | <a name="module_aci_fabric_l2_mtu"></a> [aci\_fabric\_l2\_mtu](#module\_aci\_fabric\_l2\_mtu) | ./modules/terraform-aci-fabric-l2-mtu | n/a |
+| <a name="module_aci_fabric_leaf_interface_policy_group"></a> [aci\_fabric\_leaf\_interface\_policy\_group](#module\_aci\_fabric\_leaf\_interface\_policy\_group) | ./modules/terraform-aci-fabric-leaf-interface-policy-group | n/a |
 | <a name="module_aci_fabric_leaf_interface_profile_auto"></a> [aci\_fabric\_leaf\_interface\_profile\_auto](#module\_aci\_fabric\_leaf\_interface\_profile\_auto) | ./modules/terraform-aci-fabric-leaf-interface-profile | n/a |
 | <a name="module_aci_fabric_leaf_interface_profile_manual"></a> [aci\_fabric\_leaf\_interface\_profile\_manual](#module\_aci\_fabric\_leaf\_interface\_profile\_manual) | ./modules/terraform-aci-fabric-leaf-interface-profile | n/a |
 | <a name="module_aci_fabric_leaf_switch_configuration"></a> [aci\_fabric\_leaf\_switch\_configuration](#module\_aci\_fabric\_leaf\_switch\_configuration) | ./modules/terraform-aci-switch-configuration | n/a |

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -330,6 +330,20 @@ module "aci_fabric_leaf_switch_policy_group" {
   ]
 }
 
+module "aci_fabric_leaf_interface_policy_group" {
+  source = "./modules/terraform-aci-fabric-leaf-interface-policy-group"
+
+  for_each          = { for pg in try(local.fabric_policies.leaf_interface_policy_groups, []) : pg.name => pg if local.modules.aci_fabric_leaf_interface_policy_group && var.manage_fabric_policies }
+  name              = "${each.value.name}${local.defaults.apic.fabric_policies.leaf_interface_policy_groups.name_suffix}"
+  link_level_policy = try("${each.value.link_level_policy}${local.defaults.apic.fabric_policies.link_level_policies.name_suffix}", "")
+  monitoring_policy = try("${each.value.node_control_policy}${local.defaults.apic.fabric_policies.switch_policies.node_control_policies.name_suffix}", "")
+
+  depends_on = [
+    module.aci_link_level_policy,
+    module.aci_node_control_policy,
+  ]
+}
+
 module "aci_fabric_spine_switch_policy_group" {
   source = "./modules/terraform-aci-fabric-spine-switch-policy-group"
 

--- a/defaults/modules.yaml
+++ b/defaults/modules.yaml
@@ -60,6 +60,7 @@ modules:
   aci_fabric_l2_mtu: true
   aci_fabric_leaf_interface_profile: true
   aci_fabric_leaf_switch_policy_group: true
+  aci_fabric_leaf_interface_policy_group: true
   aci_fabric_leaf_switch_profile: true
   aci_fabric_pod_policy_group: true
   aci_fabric_pod_profile: true

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/.terraform-docs.yml
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/.terraform-docs.yml
@@ -1,0 +1,34 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Terraform ACI Fabric Leaf Interface Policy Group Module
+
+  Manages ACI Fabric Leaf Interface Policy Group
+
+  Location in GUI:
+  `Fabric` » `Fabric Policies` » `Interfaces` » `Leaf Interfaces » `Policy Groups` » `Leaf Fabric Port`
+
+  ## Examples
+
+  ```hcl
+  {{ include "./examples/complete/main.tf" }}
+  ```
+
+  {{ .Requirements }}
+
+  {{ .Providers }}
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Resources }}
+
+output:
+  file: README.md
+  mode: replace
+
+sort:
+  enabled: false

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/README.md
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/README.md
@@ -1,0 +1,57 @@
+<!-- BEGIN_TF_DOCS -->
+# Terraform ACI Fabric Leaf Interface Policy Group Module
+
+Manages ACI Fabric Leaf Interface Policy Group
+
+Location in GUI:
+`Fabric` » `Fabric Policies` » `Interfaces` » `Leaf Interfaces » `Policy Groups` » `Leaf Fabric Port`
+
+## Examples
+
+```hcl
+module "aci_fabric_leaf_interface_policy_group" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
+  version = ">= 0.8.0"
+
+  name              = "LEAFS"
+  link_level_policy = "default"
+  monitoring_policy = "default"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Leaf interface policy group name. | `string` | n/a | yes |
+| <a name="input_link_level_policy"></a> [link\_level\_policy](#input\_link\_level\_policy) | Link Level policy name. | `string` | `""` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Monitoring policy name. | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dn"></a> [dn](#output\_dn) | Distinguished name of `fabricLePortPGrp` object. |
+| <a name="output_name"></a> [name](#output\_name) | Leaf interface policy group name. |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aci_rest_managed.fabricLePortPGrp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fabricRsFIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fabricRsMonIfFabricPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/.terraform-docs.yml
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/.terraform-docs.yml
@@ -1,0 +1,24 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Fabric Leaf Interface Policy Group Example
+
+  To run this example you need to execute:
+
+  ```bash
+  $ terraform init
+  $ terraform plan
+  $ terraform apply
+  ```
+
+  Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+  ```hcl
+  {{ include "./main.tf" }}
+  ```
+
+output:
+  file: README.md
+  mode: replace

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/README.md
@@ -1,0 +1,24 @@
+<!-- BEGIN_TF_DOCS -->
+# Fabric Leaf Interface Policy Group Example
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+```hcl
+module "aci_fabric_leaf_interface_policy_group" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
+  version = ">= 0.8.0"
+
+  name              = "LEAFS"
+  link_level_policy = "default"
+  monitoring_policy = "default"
+}
+```
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/main.tf
@@ -1,0 +1,8 @@
+module "aci_fabric_leaf_interface_policy_group" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
+  version = ">= 0.8.0"
+
+  name              = "LEAFS"
+  link_level_policy = "default"
+  monitoring_policy = "default"
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/versions.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
@@ -1,0 +1,23 @@
+resource "aci_rest_managed" "fabricLePortPGrp" {
+  dn         = "uni/fabric/funcprof/leportgrp-${var.name}"
+  class_name = "fabricLePortPGrp"
+  content = {
+    name = var.name
+  }
+}
+
+resource "aci_rest_managed" "fabricRsFIfPol" {
+  dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsfIfPolol"
+  class_name = "fabricRsFIfPol"
+  content = {
+    tnPsuInstPolName = var.link_level_policy
+  }
+}
+
+resource "aci_rest_managed" "fabricRsMonIfFabricPol" {
+  dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsmonIfFabricPol"
+  class_name = "fabricRsMonIfFabricPol"
+  content = {
+    tnFabricNodeControlName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/outputs.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/outputs.tf
@@ -1,0 +1,9 @@
+output "dn" {
+  value       = aci_rest_managed.fabricLePortPGrp.id
+  description = "Distinguished name of `fabricLePortPGrp` object."
+}
+
+output "name" {
+  value       = aci_rest_managed.fabricLePortPGrp.content.name
+  description = "Leaf interface policy group name."
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/variables.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/variables.tf
@@ -1,0 +1,31 @@
+variable "name" {
+  description = "Leaf interface policy group name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "link_level_policy" {
+  description = "Link Level policy name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.link_level_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "monitoring_policy" {
+  description = "Monitoring policy name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/versions.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces the new feature to create "Leaf Fabric Port Policy Groups". There are some new files and modified section in pre-existing files:

Pre-Existing Files (new section added to support the new feature):
*defaults/defaults.yaml
*defaults/modules.yaml
*aci_fabric_policies.tf

-New files:
*modules/terraform-aci-fabric-leaf-interface-policy-group/examples
*modules/terraform-aci-fabric-leaf-interface-policy-group/.terraform-docs.yml
*modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
*modules/terraform-aci-fabric-leaf-interface-policy-group/outputs.tf
*modules/terraform-aci-fabric-leaf-interface-policy-group/README.md
*modules/terraform-aci-fabric-leaf-interface-policy-group/variables.tf
*modules/terraform-aci-fabric-leaf-interface-policy-group/versions.tf

Motivation

The feature allows to create the object for the Leaf Fabric Port Policy Group

Related Issues

Issue https://wwwin-github.cisco.com/netascode/nac-aci/issues/556 in the ACI as Code Planning backlog