### PR TITLE
Fixing L3out.name_suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,6 +384,9 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+#Mac Book DS_Store
+.DS_Store
+
 # End of https://www.gitignore.io/api/git,linux,pydev,python,windows,pycharm+all,jupyternotebook,vim,webstorm,emacs,dotenv
 
 # vsCode

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -338,6 +338,13 @@ repos:
             "./modules/terraform-aci-fabric-leaf-switch-policy-group/examples/complete",
           ]
       - id: terraform-docs-system
+        args: ["./modules/terraform-aci-fabric-leaf-interface-policy-group"]
+      - id: terraform-docs-system
+        args:
+          [
+            "./modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete",
+          ]
+      - id: terraform-docs-system
         args: ["./modules/terraform-aci-fabric-leaf-switch-profile"]
       - id: terraform-docs-system
         args:

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Additional example repositories:
 | <a name="module_aci_fabric_isis_bfd"></a> [aci\_fabric\_isis\_bfd](#module\_aci\_fabric\_isis\_bfd) | ./modules/terraform-aci-fabric-isis-bfd | n/a |
 | <a name="module_aci_fabric_isis_policy"></a> [aci\_fabric\_isis\_policy](#module\_aci\_fabric\_isis\_policy) | ./modules/terraform-aci-fabric-isis-policy | n/a |
 | <a name="module_aci_fabric_l2_mtu"></a> [aci\_fabric\_l2\_mtu](#module\_aci\_fabric\_l2\_mtu) | ./modules/terraform-aci-fabric-l2-mtu | n/a |
+| <a name="module_aci_fabric_leaf_interface_policy_group"></a> [aci\_fabric\_leaf\_interface\_policy\_group](#module\_aci\_fabric\_leaf\_interface\_policy\_group) | ./modules/terraform-aci-fabric-leaf-interface-policy-group | n/a |
 | <a name="module_aci_fabric_leaf_interface_profile_auto"></a> [aci\_fabric\_leaf\_interface\_profile\_auto](#module\_aci\_fabric\_leaf\_interface\_profile\_auto) | ./modules/terraform-aci-fabric-leaf-interface-profile | n/a |
 | <a name="module_aci_fabric_leaf_interface_profile_manual"></a> [aci\_fabric\_leaf\_interface\_profile\_manual](#module\_aci\_fabric\_leaf\_interface\_profile\_manual) | ./modules/terraform-aci-fabric-leaf-interface-profile | n/a |
 | <a name="module_aci_fabric_leaf_switch_configuration"></a> [aci\_fabric\_leaf\_switch\_configuration](#module\_aci\_fabric\_leaf\_switch\_configuration) | ./modules/terraform-aci-switch-configuration | n/a |

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -335,12 +335,10 @@ module "aci_fabric_leaf_interface_policy_group" {
 
   for_each          = { for pg in try(local.fabric_policies.leaf_interface_policy_groups, []) : pg.name => pg if local.modules.aci_fabric_leaf_interface_policy_group && var.manage_fabric_policies }
   name              = "${each.value.name}${local.defaults.apic.fabric_policies.leaf_interface_policy_groups.name_suffix}"
-  link_level_policy = try("${each.value.link_level_policy}${local.defaults.apic.fabric_policies.link_level_policies.name_suffix}", "")
-  monitoring_policy = try("${each.value.node_control_policy}${local.defaults.apic.fabric_policies.switch_policies.node_control_policies.name_suffix}", "")
+  link_level_policy = try("${each.value.link_level_policy}${local.defaults.apic.fabric_policies.interface_policies.link_level_policies.name_suffix}", "")
 
   depends_on = [
     module.aci_link_level_policy,
-    module.aci_node_control_policy,
   ]
 }
 

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -330,6 +330,20 @@ module "aci_fabric_leaf_switch_policy_group" {
   ]
 }
 
+module "aci_fabric_leaf_interface_policy_group" {
+  source = "./modules/terraform-aci-fabric-leaf-interface-policy-group"
+
+  for_each          = { for pg in try(local.fabric_policies.leaf_interface_policy_groups, []) : pg.name => pg if local.modules.aci_fabric_leaf_interface_policy_group && var.manage_fabric_policies }
+  name              = "${each.value.name}${local.defaults.apic.fabric_policies.leaf_interface_policy_groups.name_suffix}"
+  link_level_policy = try("${each.value.link_level_policy}${local.defaults.apic.fabric_policies.link_level_policies.name_suffix}", "")
+  monitoring_policy = try("${each.value.node_control_policy}${local.defaults.apic.fabric_policies.switch_policies.node_control_policies.name_suffix}", "")
+
+  depends_on = [
+    module.aci_link_level_policy,
+    module.aci_node_control_policy,
+  ]
+}
+
 module "aci_fabric_spine_switch_policy_group" {
   source = "./modules/terraform-aci-fabric-spine-switch-policy-group"
 

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -1068,10 +1068,10 @@ locals {
   node_profiles_auto = flatten([
     for tenant in local.tenants : [
       for l3out in try(tenant.l3outs, []) : {
-        key                       = format("%s/%s", tenant.name, l3out.name)
+        key                       = format("%s/%s", tenant.name, l3out.name_suffix)
         tenant                    = tenant.name
-        l3out                     = l3out.name
-        name                      = l3out.name
+        l3out                     = l3out.name_suffix
+        name                      = l3out.name_suffix
         multipod                  = try(l3out.multipod, local.defaults.apic.tenants.l3outs.multipod)
         remote_leaf               = try(l3out.remote_leaf, local.defaults.apic.tenants.l3outs.remote_leaf)
         bgp_protocol_profile_name = try(l3out.bgp.name, "")
@@ -1157,9 +1157,9 @@ locals {
       for l3out in try(tenant.l3outs, []) : [
         for np in try(l3out.node_profiles, []) : [
           for ip in try(np.interface_profiles, []) : {
-            key                          = format("%s/%s/%s/%s", tenant.name, l3out.name, np.name, ip.name)
+            key                          = format("%s/%s/%s/%s", tenant.name, l3out.name_suffix, np.name, ip.name)
             tenant                       = tenant.name
-            l3out                        = l3out.name
+            l3out                        = l3out.name_suffix
             node_profile                 = np.name
             name                         = "${ip.name}${local.defaults.apic.tenants.l3outs.node_profiles.interface_profiles.name_suffix}"
             description                  = try(ip.description, "")

--- a/defaults/modules.yaml
+++ b/defaults/modules.yaml
@@ -60,6 +60,7 @@ modules:
   aci_fabric_l2_mtu: true
   aci_fabric_leaf_interface_profile: true
   aci_fabric_leaf_switch_policy_group: true
+  aci_fabric_leaf_interface_policy_group: true
   aci_fabric_leaf_switch_profile: true
   aci_fabric_pod_policy_group: true
   aci_fabric_pod_profile: true

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/.terraform-docs.yml
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/.terraform-docs.yml
@@ -1,0 +1,34 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Terraform ACI Fabric Leaf Interface Policy Group Module
+
+  Manages ACI Fabric Leaf Interface Policy Group
+
+  Location in GUI:
+  `Fabric` » `Fabric Policies` » `Interfaces` » `Leaf Interfaces » `Policy Groups` » `Leaf Fabric Port`
+
+  ## Examples
+
+  ```hcl
+  {{ include "./examples/complete/main.tf" }}
+  ```
+
+  {{ .Requirements }}
+
+  {{ .Providers }}
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Resources }}
+
+output:
+  file: README.md
+  mode: replace
+
+sort:
+  enabled: false

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/.terraform-docs.yml
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/.terraform-docs.yml
@@ -8,7 +8,7 @@ content: |-
   Manages ACI Fabric Leaf Interface Policy Group
 
   Location in GUI:
-  `Fabric` » `Fabric Policies` » `Interfaces` » `Leaf Interfaces » `Policy Groups` » `Leaf Fabric Port`
+  `Fabric` » `Fabric Policies` » `Interfaces` » `Leaf Interfaces` » `Policy Groups` » `Leaf Fabric Port`
 
   ## Examples
 

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/README.md
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/README.md
@@ -4,18 +4,17 @@
 Manages ACI Fabric Leaf Interface Policy Group
 
 Location in GUI:
-`Fabric` » `Fabric Policies` » `Interfaces` » `Leaf Interfaces » `Policy Groups` » `Leaf Fabric Port`
+`Fabric` » `Fabric Policies` » `Interfaces` » `Leaf Interfaces` » `Policy Groups` » `Leaf Fabric Port`
 
 ## Examples
 
 ```hcl
 module "aci_fabric_leaf_interface_policy_group" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
-  version = ">= 0.8.0"
+  version = ">= 1.0.2"
 
   name              = "LEAFS"
   link_level_policy = "default"
-  monitoring_policy = "default"
 }
 ```
 
@@ -23,14 +22,14 @@ module "aci_fabric_leaf_interface_policy_group" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.15.0 |
 
 ## Inputs
 
@@ -38,7 +37,6 @@ module "aci_fabric_leaf_interface_policy_group" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Leaf interface policy group name. | `string` | n/a | yes |
 | <a name="input_link_level_policy"></a> [link\_level\_policy](#input\_link\_level\_policy) | Link Level policy name. | `string` | `""` | no |
-| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Monitoring policy name. | `string` | `""` | no |
 
 ## Outputs
 
@@ -53,5 +51,4 @@ module "aci_fabric_leaf_interface_policy_group" {
 |------|------|
 | [aci_rest_managed.fabricLePortPGrp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fabricRsFIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
-| [aci_rest_managed.fabricRsMonIfFabricPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/README.md
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/README.md
@@ -1,0 +1,57 @@
+<!-- BEGIN_TF_DOCS -->
+# Terraform ACI Fabric Leaf Interface Policy Group Module
+
+Manages ACI Fabric Leaf Interface Policy Group
+
+Location in GUI:
+`Fabric` » `Fabric Policies` » `Interfaces` » `Leaf Interfaces » `Policy Groups` » `Leaf Fabric Port`
+
+## Examples
+
+```hcl
+module "aci_fabric_leaf_interface_policy_group" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
+  version = ">= 0.8.0"
+
+  name              = "LEAFS"
+  link_level_policy = "default"
+  monitoring_policy = "default"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Leaf interface policy group name. | `string` | n/a | yes |
+| <a name="input_link_level_policy"></a> [link\_level\_policy](#input\_link\_level\_policy) | Link Level policy name. | `string` | `""` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Monitoring policy name. | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dn"></a> [dn](#output\_dn) | Distinguished name of `fabricLePortPGrp` object. |
+| <a name="output_name"></a> [name](#output\_name) | Leaf interface policy group name. |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aci_rest_managed.fabricLePortPGrp](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fabricRsFIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fabricRsMonIfFabricPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/.terraform-docs.yml
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/.terraform-docs.yml
@@ -1,0 +1,24 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Fabric Leaf Interface Policy Group Example
+
+  To run this example you need to execute:
+
+  ```bash
+  $ terraform init
+  $ terraform plan
+  $ terraform apply
+  ```
+
+  Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+  ```hcl
+  {{ include "./main.tf" }}
+  ```
+
+output:
+  file: README.md
+  mode: replace

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/README.md
@@ -1,0 +1,24 @@
+<!-- BEGIN_TF_DOCS -->
+# Fabric Leaf Interface Policy Group Example
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+```hcl
+module "aci_fabric_leaf_interface_policy_group" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
+  version = ">= 0.8.0"
+
+  name              = "LEAFS"
+  link_level_policy = "default"
+  monitoring_policy = "default"
+}
+```
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/README.md
@@ -14,11 +14,10 @@ Note that this example will create resources. Resources can be destroyed with `t
 ```hcl
 module "aci_fabric_leaf_interface_policy_group" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
-  version = ">= 0.8.0"
+  version = ">= 1.0.2"
 
   name              = "LEAFS"
   link_level_policy = "default"
-  monitoring_policy = "default"
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/main.tf
@@ -1,8 +1,7 @@
 module "aci_fabric_leaf_interface_policy_group" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
-  version = ">= 0.8.0"
+  version = ">= 1.0.2"
 
   name              = "LEAFS"
   link_level_policy = "default"
-  monitoring_policy = "default"
 }

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/main.tf
@@ -1,0 +1,8 @@
+module "aci_fabric_leaf_interface_policy_group" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-fabric-leaf-interface-policy-group"
+  version = ">= 0.8.0"
+
+  name              = "LEAFS"
+  link_level_policy = "default"
+  monitoring_policy = "default"
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/versions.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/versions.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/examples/complete/versions.tf
@@ -1,11 +1,11 @@
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.0.0"
+      version = ">= 2.15.0"
     }
   }
 }

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
@@ -7,17 +7,10 @@ resource "aci_rest_managed" "fabricLePortPGrp" {
 }
 
 resource "aci_rest_managed" "fabricRsFIfPol" {
-  dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsfIfPolol"
+  dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsfIfPol"
   class_name = "fabricRsFIfPol"
   content = {
     tnFabricFIfPolName = var.link_level_policy
   }
 }
 
-resource "aci_rest_managed" "fabricRsMonIfFabricPol" {
-  dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsmonIfFabricPol"
-  class_name = "fabricRsMonIfFabricPol"
-  content = {
-    tnMonFabricPolName = var.monitoring_policy
-  }
-}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
@@ -1,0 +1,23 @@
+resource "aci_rest_managed" "fabricLePortPGrp" {
+  dn         = "uni/fabric/funcprof/leportgrp-${var.name}"
+  class_name = "fabricLePortPGrp"
+  content = {
+    name = var.name
+  }
+}
+
+resource "aci_rest_managed" "fabricRsFIfPol" {
+  dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsfIfPolol"
+  class_name = "fabricRsFIfPol"
+  content = {
+    tnPsuInstPolName = var.link_level_policy
+  }
+}
+
+resource "aci_rest_managed" "fabricRsMonIfFabricPol" {
+  dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsmonIfFabricPol"
+  class_name = "fabricRsMonIfFabricPol"
+  content = {
+    tnFabricNodeControlName = var.monitoring_policy
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/main.tf
@@ -10,7 +10,7 @@ resource "aci_rest_managed" "fabricRsFIfPol" {
   dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsfIfPolol"
   class_name = "fabricRsFIfPol"
   content = {
-    tnPsuInstPolName = var.link_level_policy
+    tnFabricFIfPolName = var.link_level_policy
   }
 }
 
@@ -18,6 +18,6 @@ resource "aci_rest_managed" "fabricRsMonIfFabricPol" {
   dn         = "${aci_rest_managed.fabricLePortPGrp.dn}/rsmonIfFabricPol"
   class_name = "fabricRsMonIfFabricPol"
   content = {
-    tnFabricNodeControlName = var.monitoring_policy
+    tnMonFabricPolName = var.monitoring_policy
   }
 }

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/outputs.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/outputs.tf
@@ -1,0 +1,9 @@
+output "dn" {
+  value       = aci_rest_managed.fabricLePortPGrp.id
+  description = "Distinguished name of `fabricLePortPGrp` object."
+}
+
+output "name" {
+  value       = aci_rest_managed.fabricLePortPGrp.content.name
+  description = "Leaf interface policy group name."
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/variables.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/variables.tf
@@ -19,13 +19,3 @@ variable "link_level_policy" {
   }
 }
 
-variable "monitoring_policy" {
-  description = "Monitoring policy name."
-  type        = string
-  default     = ""
-
-  validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
-  }
-}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/variables.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/variables.tf
@@ -1,0 +1,31 @@
+variable "name" {
+  description = "Leaf interface policy group name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "link_level_policy" {
+  description = "Link Level policy name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.link_level_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "monitoring_policy" {
+  description = "Monitoring policy name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/versions.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/modules/terraform-aci-fabric-leaf-interface-policy-group/versions.tf
+++ b/modules/terraform-aci-fabric-leaf-interface-policy-group/versions.tf
@@ -1,11 +1,11 @@
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.0.0"
+      version = ">= 2.15.0"
     }
   }
 }


### PR DESCRIPTION
This pull request introduces the fixes for the  l3out.name_suffix reference in different modules. There are some changes in pre-existing files.

Motivation

This modifications are intended to fix the l3out name references to avoid conflict when defining name_suffix.

Related Issues

Issue https://wwwin-github.cisco.com/netascode/nac-aci/issues/625 in the ACI as Code Planning backlog