### PR TITLE
add support for fvSubnet for mgmtInB #265

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -743,11 +743,10 @@ locals {
         contract_imported_consumers = try([for contract in epg.contracts.imported_consumers : "${contract}${local.defaults.apic.tenants.imported_contracts.name_suffix}"], [])
         static_routes               = try(epg.static_routes, [])
         subnets = [for subnet in try(epg.subnets, []) : {
-          description           = try(subnet.description, "")
-          ip                    = subnet.ip
-          public                = try(subnet.public, local.defaults.apic.tenants.application_profiles.endpoint_groups.subnets.public)
-          shared                = try(subnet.shared, local.defaults.apic.tenants.application_profiles.endpoint_groups.subnets.shared)
-          ip_dataplane_learning = try(subnet.ip_dataplane_learning, null)
+          description = try(subnet.description, "")
+          ip          = subnet.ip
+          public      = try(subnet.public, local.defaults.apic.tenants.application_profiles.endpoint_groups.subnets.public)
+          shared      = try(subnet.shared, local.defaults.apic.tenants.application_profiles.endpoint_groups.subnets.shared)
         }]
       }
     ] if tenant.name == "mgmt"

--- a/modules/terraform-aci-inband-endpoint-group/README.md
+++ b/modules/terraform-aci-inband-endpoint-group/README.md
@@ -46,7 +46,7 @@ module "aci_inband_endpoint_group" {
 | <a name="input_contract_providers"></a> [contract\_providers](#input\_contract\_providers) | List of contract providers. | `list(string)` | `[]` | no |
 | <a name="input_contract_imported_consumers"></a> [contract\_imported\_consumers](#input\_contract\_imported\_consumers) | List of imported contract consumers. | `list(string)` | `[]` | no |
 | <a name="input_static_routes"></a> [static\_routes](#input\_static\_routes) | List of inband Static routes | `list(string)` | `[]` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets. Default value `public`: `false`. Default value `shared`: `false`. Default value `igmp_querier`: `false`. Default value `nd_ra_prefix`: `true`. Default value `no_default_gateway`: `false`. `nlb_mode` allowed values: `mode-mcast-igmp`, `mode-uc` or `mode-mcast-static`. | <pre>list(object({<br/>    description           = optional(string, "")<br/>    ip                    = string<br/>    public                = optional(bool, false)<br/>    shared                = optional(bool, false)<br/>    ip_dataplane_learning = optional(bool, null)<br/>  }))</pre> | `[]` | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets. Default value `public`: `false`. Default value `shared`: `false`. Default value `igmp_querier`: `false`. Default value `nd_ra_prefix`: `true`. Default value `no_default_gateway`: `false`. `nlb_mode` allowed values: `mode-mcast-igmp`, `mode-uc` or `mode-mcast-static`. | <pre>list(object({<br/>    description = optional(string, "")<br/>    ip          = string<br/>    public      = optional(bool, false)<br/>    shared      = optional(bool, false)<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-inband-endpoint-group/main.tf
+++ b/modules/terraform-aci-inband-endpoint-group/main.tf
@@ -56,9 +56,8 @@ resource "aci_rest_managed" "fvSubnet" {
   dn         = "${aci_rest_managed.mgmtInB.dn}/subnet-[${each.value.ip}]"
   class_name = "fvSubnet"
   content = {
-    ip           = each.value.ip
-    descr        = each.value.description != null ? each.value.description : ""
-    scope        = join(",", concat(each.value.public == true ? ["public"] : ["private"], each.value.shared == true ? ["shared"] : []))
-    ipDPLearning = each.value.ip_dataplane_learning != null ? (each.value.ip_dataplane_learning == true ? "enabled" : "disabled") : null
+    ip    = each.value.ip
+    descr = each.value.description != null ? each.value.description : ""
+    scope = join(",", concat(each.value.public == true ? ["public"] : ["private"], each.value.shared == true ? ["shared"] : []))
   }
 }

--- a/modules/terraform-aci-inband-endpoint-group/variables.tf
+++ b/modules/terraform-aci-inband-endpoint-group/variables.tf
@@ -83,11 +83,10 @@ variable "static_routes" {
 variable "subnets" {
   description = "List of subnets. Default value `public`: `false`. Default value `shared`: `false`. Default value `igmp_querier`: `false`. Default value `nd_ra_prefix`: `true`. Default value `no_default_gateway`: `false`. `nlb_mode` allowed values: `mode-mcast-igmp`, `mode-uc` or `mode-mcast-static`."
   type = list(object({
-    description           = optional(string, "")
-    ip                    = string
-    public                = optional(bool, false)
-    shared                = optional(bool, false)
-    ip_dataplane_learning = optional(bool, null)
+    description = optional(string, "")
+    ip          = string
+    public      = optional(bool, false)
+    shared      = optional(bool, false)
   }))
   default = []
 


### PR DESCRIPTION
Fix for #265 

Changes needed to schema:
```
apic:
  tenants:
    - name: mgmt
      inb_endpoint_groups:
        - name: default
          vlan: 11
          bridge_domain: inb
          contracts:
            providers:
              - permit-to-10.1.11.0-24
          subnets:
            - ip: 10.1.11.1/24
              public: true
              shared: true
```
