### PR TITLE
change reference to eigrp keychain policy from l3out eigrp policy

### DIFF
--- a/modules/terraform-aci-l3out-interface-profile/main.tf
+++ b/modules/terraform-aci-l3out-interface-profile/main.tf
@@ -206,7 +206,7 @@ resource "aci_rest_managed" "eigrpAuthIfP" {
 
 resource "aci_rest_managed" "eigrpRsKeyChainPol" {
   count      = var.eigrp_interface_profile_name != "" && var.eigrp_keychain_policy != "" ? 1 : 0
-  dn         = "${aci_rest_managed.eigrpAuthIfP[0].dn}/keychainp-${var.eigrp_keychain_policy}"
+  dn         = "${aci_rest_managed.eigrpAuthIfP[0].dn}/rsKeyChainPol"
   class_name = "eigrpRsKeyChainPol"
   content = {
     tnFvKeyChainPolName = var.eigrp_keychain_policy


### PR DESCRIPTION
As per internal issue #667, it looks as if the existing resource was trying to create a direct/local mapping to the policy when it should have been creating a reference to a remote policy managed elsewhere in the tenant (similar to how we do EIGRP Interface Policies in the same module).