### PR TITLE
Add ESG external subnet selectors support

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -694,6 +694,11 @@ locals {
             value       = sel.value
             description = try(sel.description, "")
           }]
+          ip_external_subnet_selectors = [for sel in try(esg.ip_external_subnet_selectors, []) : {
+            value       = sel.value
+            description = try(sel.description, "")
+            shared      = try(sel.shared, "false")
+          }]
         }
       ]
     ]
@@ -703,23 +708,24 @@ locals {
 module "aci_endpoint_security_group" {
   source = "./modules/terraform-aci-endpoint-security-group"
 
-  for_each                    = { for esg in local.endpoint_security_groups : esg.key => esg if local.modules.aci_endpoint_security_group && var.manage_tenants }
-  tenant                      = each.value.tenant
-  application_profile         = each.value.application_profile
-  name                        = each.value.name
-  description                 = each.value.description
-  vrf                         = each.value.vrf
-  shutdown                    = each.value.shutdown
-  intra_esg_isolation         = each.value.intra_esg_isolation
-  preferred_group             = each.value.preferred_group
-  contract_consumers          = each.value.contract_consumers
-  contract_providers          = each.value.contract_providers
-  contract_imported_consumers = each.value.contract_imported_consumers
-  contract_intra_esgs         = each.value.contract_intra_esgs
-  esg_contract_masters        = each.value.esg_contract_masters
-  tag_selectors               = each.value.tag_selectors
-  epg_selectors               = each.value.epg_selectors
-  ip_subnet_selectors         = each.value.ip_subnet_selectors
+  for_each                     = { for esg in local.endpoint_security_groups : esg.key => esg if local.modules.aci_endpoint_security_group && var.manage_tenants }
+  tenant                       = each.value.tenant
+  application_profile          = each.value.application_profile
+  name                         = each.value.name
+  description                  = each.value.description
+  vrf                          = each.value.vrf
+  shutdown                     = each.value.shutdown
+  intra_esg_isolation          = each.value.intra_esg_isolation
+  preferred_group              = each.value.preferred_group
+  contract_consumers           = each.value.contract_consumers
+  contract_providers           = each.value.contract_providers
+  contract_imported_consumers  = each.value.contract_imported_consumers
+  contract_intra_esgs          = each.value.contract_intra_esgs
+  esg_contract_masters         = each.value.esg_contract_masters
+  tag_selectors                = each.value.tag_selectors
+  epg_selectors                = each.value.epg_selectors
+  ip_subnet_selectors          = each.value.ip_subnet_selectors
+  ip_external_subnet_selectors = each.value.ip_external_subnet_selectors
 
   depends_on = [
     module.aci_tenant,

--- a/modules/terraform-aci-endpoint-security-group/README.md
+++ b/modules/terraform-aci-endpoint-security-group/README.md
@@ -75,6 +75,22 @@ module "aci_endpoint_security_group" {
       description = "foo"
     }
   ]
+  ip_external_subnet_selectors = [
+    {
+      value = "1.1.5.0/24"
+    },
+    {
+      value = "1.1.6.0/24"
+    },
+    {
+      value = "1.1.7.0/24"
+    },
+    {
+      value       = "1.1.8.0/24"
+      description = "foo"
+      shared = true
+    }
+  ]
 }
 ```
 

--- a/modules/terraform-aci-endpoint-security-group/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-security-group/examples/complete/README.md
@@ -78,6 +78,22 @@ module "aci_endpoint_security_group" {
       description = "foo"
     }
   ]
+ip_external_subnet_selectors = [
+    {
+      value = "1.1.5.0/24"
+    },
+    {
+      value = "1.1.6.0/24"
+    },
+    {
+      value = "1.1.7.0/24"
+    },
+    {
+      value       = "1.1.8.0/24"
+      description = "foo"
+      shared = true
+    }
+  ]
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-endpoint-security-group/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-security-group/examples/complete/main.tf
@@ -64,4 +64,20 @@ module "aci_endpoint_security_group" {
       description = "foo"
     }
   ]
+  ip_external_subnet_selectors = [
+    {
+      value = "1.1.1.0/24"
+    },
+    {
+      value = "1.1.2.0/24"
+    },
+    {
+      value = "1.1.3.0/24"
+    },
+    {
+      value       = "1.1.4.0/24"
+      description = "foo"
+      shared      = true
+    }
+  ]
 }

--- a/modules/terraform-aci-endpoint-security-group/main.tf
+++ b/modules/terraform-aci-endpoint-security-group/main.tf
@@ -127,3 +127,17 @@ resource "aci_rest_managed" "fvEPSelector" {
     aci_rest_managed.fvRsScope,
   ]
 }
+
+resource "aci_rest_managed" "fvExternalSubnetSelector" {
+  for_each   = { for ess in var.ip_external_subnet_selectors : "${ess.value}" => ess }
+  dn         = "${aci_rest_managed.fvESg.dn}/extsubselector-[${each.key}]"
+  class_name = "fvExternalSubnetSelector"
+  content = {
+    descr           = each.value.description
+    shared          = each.value.shared
+  }
+
+  depends_on = [
+    aci_rest_managed.fvRsScope,
+  ]
+}

--- a/modules/terraform-aci-endpoint-security-group/variables.tf
+++ b/modules/terraform-aci-endpoint-security-group/variables.tf
@@ -250,3 +250,27 @@ variable "ip_subnet_selectors" {
     error_message = "`description`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, }`, `~`, `?`, `&`, `+`. Maximum characters: 128."
   }
 }
+
+variable "ip_external_subnet_selectors" {
+  description = "List of IP subnet selectors."
+  type = list(object({
+    value       = string
+    description = optional(string, "")
+    shared      = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for ess in var.ip_external_subnet_selectors : can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}\\/([0-9]){1,2}$", ess.value))
+    ])
+    error_message = "`value`: Valid ip format example: 192.168.1.0/24."
+  }
+
+  validation {
+    condition = alltrue([
+      for ess in var.ip_external_subnet_selectors : ess.description == null || can(regex("^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]{0,128}$", ess.description))
+    ])
+    error_message = "`description`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, }`, `~`, `?`, `&`, `+`. Maximum characters: 128."
+  }
+}


### PR DESCRIPTION
- Add external_subnet_selectors to endpoint security groups
- Support for external subnet selection in ESG configuration
- Update documentation and examples for external subnet selectors
- Include validation and proper variable definitions