### PR TITLE
netascode#533-BFD_Multihop_Policy_L3O_Node_Profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Additional example repositories:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_local"></a> [local](#provider\_local) | 2.5.3 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.3.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Resources

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -989,17 +989,10 @@ locals {
           bgp_protocol_profile_name = try(np.bgp.name, "")
           bgp_timer_policy          = try("${np.bgp.timer_policy}${local.defaults.apic.tenants.policies.bgp_timer_policies.name_suffix}", "")
           bgp_as_path_policy        = try("${np.bgp.as_path_policy}${local.defaults.apic.tenants.policies.bgp_best_path_policies.name_suffix}", "")
-          bfd_multihop = try({
-            auth_key_id              = np.bfd_multihop.auth_key_id
-            auth_key                 = np.bfd_multihop.auth_key
-            auth_type                = np.bfd_multihop.auth_type
-            bfd_multihop_node_policy = "${np.bfd_multihop.bfd_multihop_node_policy}${local.defaults.apic.tenants.policies.bfd_multihop_node_policies.name_suffix}"
-            }, {
-            auth_key_id              = 1
-            auth_key                 = ""
-            auth_type                = "sha1"
-            bfd_multihop_node_policy = ""
-          })
+          bfd_multihop_node_policy  = try("${np.bfd_multihop_node_policy}${local.defaults.apic.tenants.policies.bfd_multihop_node_policies.name_suffix}")
+          bfd_multihop_auth_key_id  = try(np.bfd_multihop_auth.key_id, local.defaults.apic.tenants.l3outs.node_profiles.bfd_multihop_auth.key_id)
+          bfd_multihop_auth_key     = try(np.bfd_multihop_auth.key, null)
+          bfd_multihop_auth_type    = try(np.bfd_multihop_auth.type, local.defaults.apic.tenants.l3outs.node_profiles.bfd_multihop_auth.type)
           nodes = [for node in try(np.nodes, []) : {
             node_id               = node.node_id
             pod_id                = try(node.pod_id, [for node_ in local.node_policies.nodes : node_.pod if node_.id == node.node_id][0], local.defaults.apic.tenants.l3outs.node_profiles.nodes.pod)
@@ -1070,6 +1063,10 @@ module "aci_l3out_node_profile_manual" {
   bgp_as_path_policy        = each.value.bgp_as_path_policy
   nodes                     = each.value.nodes
   bgp_peers                 = each.value.bgp_peers
+  bfd_multihop_node_policy  = each.value.bfd_multihop_node_policy
+  bfd_multihop_auth_key_id  = each.value.bfd_multihop_auth_key_id
+  bfd_multihop_auth_key     = each.value.bfd_multihop_auth_key
+  bfd_multihop_auth_type    = each.value.bfd_multihop_auth_type
 
   depends_on = [
     module.aci_tenant,
@@ -1091,6 +1088,10 @@ locals {
         bgp_protocol_profile_name = try(l3out.bgp.name, "")
         bgp_timer_policy          = try("${l3out.bgp.timer_policy}${local.defaults.apic.tenants.policies.bgp_timer_policies.name_suffix}", "")
         bgp_as_path_policy        = try("${l3out.bgp.as_path_policy}${local.defaults.apic.tenants.policies.bgp_best_path_policies.name_suffix}", "")
+        bfd_multihop_node_policy  = try("${l3out.bfd_multihop_node_policy}${local.defaults.apic.tenants.policies.bfd_multihop_node_policies.name_suffix}", "")
+        bfd_multihop_auth_key_id  = try(l3out.bfd_multihop_auth.key_id, local.defaults.apic.tenants.l3outs.bfd_multihop_auth.key_id)
+        bfd_multihop_auth_key     = try(l3out.bfd_multihop_auth.key, "")
+        bfd_multihop_auth_type    = try(l3out.bfd_multihop_auth.type, local.defaults.apic.tenants.l3outs.bfd_multihop_auth.type)
         nodes = [for node in try(l3out.nodes, []) : {
           node_id               = node.node_id
           pod_id                = try(node.pod_id, [for node_ in local.node_policies.nodes : node_.pod if node_.id == node.node_id][0], local.defaults.apic.tenants.l3outs.nodes.pod)
@@ -1160,6 +1161,10 @@ module "aci_l3out_node_profile_auto" {
   bgp_as_path_policy        = each.value.bgp_as_path_policy
   nodes                     = each.value.nodes
   bgp_peers                 = each.value.bgp_peers
+  bfd_multihop_node_policy  = each.value.bfd_multihop_node_policy
+  bfd_multihop_auth_key_id  = each.value.bfd_multihop_auth_key_id
+  bfd_multihop_auth_key     = each.value.bfd_multihop_auth_key
+  bfd_multihop_auth_type    = each.value.bfd_multihop_auth_type
 
   depends_on = [
     module.aci_tenant,

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -901,6 +901,9 @@ defaults:
           source: static
         dhcp_labels:
           scope: infra
+        bfd_multihop_auth:
+          type: none
+          key_id: 1
         nodes:
           pod: 1
           router_id_as_loopback: true
@@ -946,6 +949,9 @@ defaults:
               start_timer: 0
         node_profiles:
           name_suffix: ""
+          bfd_multihop_auth:
+            type: none
+            key_id: 1
           bgp_peers:
             allow_self_as: false
             as_override: false

--- a/modules/terraform-aci-l3out-node-profile/README.md
+++ b/modules/terraform-aci-l3out-node-profile/README.md
@@ -110,7 +110,9 @@ module "aci_l3out_node_profile" {
 | <a name="input_bgp_protocol_profile_name"></a> [bgp\_protocol\_profile\_name](#input\_bgp\_protocol\_profile\_name) | BGP Protocol Name. | `string` | `""` | no |
 | <a name="input_bgp_timer_policy"></a> [bgp\_timer\_policy](#input\_bgp\_timer\_policy) | Node Profile's BGP Timer Policy | `string` | `""` | no |
 | <a name="input_bgp_as_path_policy"></a> [bgp\_as\_path\_policy](#input\_bgp\_as\_path\_policy) | Node Profile's BGP AS-Path Policy | `string` | `""` | no |
-| <a name="input_bfd_multihop"></a> [bfd\_multihop](#input\_bfd\_multihop) | BFD multihop authentication parameters. | <pre>object({<br/>    auth_key_id              = optional(number, 1)<br/>    auth_key                 = optional(string, null)<br/>    auth_type                = optional(string, "sha1")<br/>    bfd_multihop_node_policy = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "auth_key": "",<br/>  "auth_key_id": 1,<br/>  "auth_type": "sha1"<br/>}</pre> | no |
+| <a name="input_bfd_multihop_auth_key_id"></a> [bfd\_multihop\_auth\_key\_id](#input\_bfd\_multihop\_auth\_key\_id) | BFD Multihop authentication key ID | `number` | `1` | no |
+| <a name="input_bfd_multihop_auth_key"></a> [bfd\_multihop\_auth\_key](#input\_bfd\_multihop\_auth\_key) | BFD Multihop authentication key | `string` | `""` | no |
+| <a name="input_bfd_multihop_auth_type"></a> [bfd\_multihop\_auth\_type](#input\_bfd\_multihop\_auth\_type) | BFD Multihop authentication type | `string` | `"none"` | no |
 
 ## Outputs
 
@@ -124,9 +126,7 @@ module "aci_l3out_node_profile" {
 | Name | Type |
 |------|------|
 | [aci_rest_managed.bfdMhNodeP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
-| [aci_rest_managed.bfdMhNodeP_](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.bfdRsMhNodePol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
-| [aci_rest_managed.bfdRsMhNodePol_](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.bgpAsP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.bgpAsP-bgpInfraPeerP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.bgpInfraPeerP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-l3out-node-profile/main.tf
+++ b/modules/terraform-aci-l3out-node-profile/main.tf
@@ -206,13 +206,23 @@ resource "aci_rest_managed" "l3extRsLNodePMplsCustQosPol" {
 }
 
 resource "aci_rest_managed" "bfdMhNodeP" {
-  count      = var.tenant == "infra" && var.sr_mpls == true && var.bfd_multihop_node_policy != "" ? 1 : 0
+  count      = var.bfd_multihop_node_policy != "" ? 1 : 0
   dn         = "${aci_rest_managed.l3extLNodeP.dn}/bfdMhNodeP"
   class_name = "bfdMhNodeP"
+
+  content = {
+    keyId = var.bfd_multihop_auth_key_id
+    key   = var.bfd_multihop_auth_key
+    type  = var.bfd_multihop_auth_type
+  }
+
+  lifecycle {
+    ignore_changes = [content["key"]]
+  }
 }
 
 resource "aci_rest_managed" "bfdRsMhNodePol" {
-  count      = var.tenant == "infra" && var.sr_mpls == true && var.bfd_multihop_node_policy != "" ? 1 : 0
+  count      = var.bfd_multihop_node_policy != "" ? 1 : 0
   dn         = "${aci_rest_managed.bfdMhNodeP[0].dn}/rsMhNodePol"
   class_name = "bfdRsMhNodePol"
   content = {
@@ -311,28 +321,5 @@ resource "aci_rest_managed" "ipRsNHTrackMember" {
   class_name = "ipRsNHTrackMember"
   content = {
     tDn = "uni/tn-${var.tenant}/trackmember-${each.value.track_list}"
-  }
-}
-
-resource "aci_rest_managed" "bfdMhNodeP_" {
-  count      = var.bfd_multihop != null ? 1 : 0
-  dn         = "${aci_rest_managed.l3extLNodeP.dn}/bfdMhNodeP"
-  class_name = "bfdMhNodeP"
-  content = {
-    keyId = var.bfd_multihop.auth_key_id
-    key   = var.bfd_multihop.auth_key
-    type  = var.bfd_multihop.auth_type
-  }
-  lifecycle {
-    ignore_changes = [content["key"]]
-  }
-}
-
-resource "aci_rest_managed" "bfdRsMhNodePol_" {
-  count      = var.bfd_multihop_node_policy != "" ? 1 : 0
-  dn         = "${aci_rest_managed.bfdMhNodeP_[0].dn}/rsMhNodePol"
-  class_name = "bfdRsMhNodePol"
-  content = {
-    tnBfdMhNodePolName = var.bfd_multihop_node_policy
   }
 }

--- a/modules/terraform-aci-l3out-node-profile/variables.tf
+++ b/modules/terraform-aci-l3out-node-profile/variables.tf
@@ -323,43 +323,30 @@ variable "bgp_as_path_policy" {
   }
 }
 
-variable "bfd_multihop" {
-  description = "BFD multihop authentication parameters."
-  type = object({
-    auth_key_id              = optional(number, 1)
-    auth_key                 = optional(string, null)
-    auth_type                = optional(string, "sha1")
-    bfd_multihop_node_policy = optional(string, "")
-  })
-
-  default = {
-    auth_key_id = 1
-    auth_key    = ""
-    auth_type   = "sha1"
-  }
+variable "bfd_multihop_auth_key_id" {
+  description = "BFD Multihop authentication key ID"
+  type        = number
+  default     = 1
 
   validation {
-    condition = (
-      var.bfd_multihop.auth_key_id == null ||
-      (var.bfd_multihop.auth_key_id >= 1 && var.bfd_multihop.auth_key_id <= 255)
-    )
+    condition     = var.bfd_multihop_auth_key_id >= 1 && var.bfd_multihop_auth_key_id <= 255
     error_message = "`auth_key_id`: Minimum value: `1`. Maximum value: `255`."
   }
+}
+
+variable "bfd_multihop_auth_key" {
+  description = "BFD Multihop authentication key"
+  type        = string
+  default     = ""
+}
+
+variable "bfd_multihop_auth_type" {
+  description = "BFD Multihop authentication type"
+  type        = string
+  default     = "none"
 
   validation {
-    condition = (
-      var.bfd_multihop.auth_key == null ||
-      var.bfd_multihop.auth_key == "" ||
-      can(regex("^[a-zA-Z0-9_.:-]{1,20}$", var.bfd_multihop.auth_key))
-    )
-    error_message = "`auth_key`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Minimum characters: 1, Maximum characters: 20."
-  }
-
-  validation {
-    condition = (
-      var.bfd_multihop.auth_type == null ||
-      contains(["sha1", "none"], var.bfd_multihop.auth_type)
-    )
+    condition     = contains(["sha1", "none"], var.bfd_multihop_auth_type)
     error_message = "`auth_type`: Allowed values are `sha1` or `none`."
   }
 }


### PR DESCRIPTION
Description
This pull request introduces - Add the option for configuring a multihop BFD multihop profile under a BGP node profile.

ACI Object
bfdMhNodeP is a child of the L3out node profile and bfdRsMhNodePol is a child of the bfdMhNodeP.
For example:
uni/tn-mytenant/out-myl3out/lnodep-mynodeprofile/bfdMhNodeP is of class bfdMhNodeP
uni/tn-mytenant/out-myl3out/lnodep-mynodeprofile/bfdMhNodeP/bfdRsMhNodePol is of class bfdRsMhNodePol

The bfdMhNodePol contains a tnBfdMhNodePolName field that must point to the existing BFD multihop policy name.
BFD multihop policies were already implemented in AAC for a different use case, so are not required for this enhancement.

Motivation
The additional option to configure BFD multihop under a BGP node profile.

Related Issues
https://wwwin-github.cisco.com/netascode/nac-aci/issues/533

Proposed Syntax
      l3outs:
        - name: 
          node_profiles:
            - name: 
              nodes:
              - node_id: 
              bfd_multihop:
                auth_type: 
               auth_key_id: 
                auth_key: 
                bfd_multihop_node_policy: 
