### PR TITLE
usegEPG VM attributes support added.

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -562,6 +562,14 @@ locals {
             name = mac_statement.name
             mac  = upper(mac_statement.mac)
           }]
+          useg_attributes_vm_statements = [for vm_statement in try(useg_epg.useg_attributes.vm_statements, []) : {
+            name     = vm_statement.name
+            type     = try(vm_statement.type, local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.useg_attributes.vm_statements.type)
+            operator = try(vm_statement.operator, local.defaults.apic.tenants.application_profiles.useg_endpoint_groups.useg_attributes.vm_statements.operator)
+            value    = vm_statement.value
+            category = try(vm_statement.category, null)
+            label    = try(vm_statement.label, null)
+          }]
           subnets = [for subnet in try(useg_epg.subnets, []) : {
             description         = try(subnet.description, "")
             ip                  = subnet.ip
@@ -636,6 +644,7 @@ module "aci_useg_endpoint_group" {
   match_type                  = each.value.useg_attributes_match_type
   ip_statements               = each.value.useg_attributes_ip_statements
   mac_statements              = each.value.useg_attributes_mac_statements
+  vm_statements               = each.value.useg_attributes_vm_statements
   subnets                     = each.value.subnets
   vmware_vmm_domains          = each.value.vmware_vmm_domains
   static_leafs = [for sl in try(each.value.static_leafs, []) : {

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1126,6 +1126,9 @@ defaults:
             match_type: any
             ip_statements:
               use_epg_subnet: true
+            vm_statements:
+              type: vm-name
+              operator: equals
           subnets:
             primary_ip: false
             public: false

--- a/modules/terraform-aci-useg-endpoint-group/README.md
+++ b/modules/terraform-aci-useg-endpoint-group/README.md
@@ -55,6 +55,16 @@ module "aci_useg_endpoint_group" {
     name = "mac_2"
     mac  = "02:aa:68:22:58:d2"
   }]
+
+  vm_statements = [{
+    name  = "vm_name"
+    value = "BackEnd"
+    }, {
+    name  = "operating_system"
+    value = "Win11"
+    type  = "guest-os"
+  }]
+
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.2.2.1/24"
@@ -86,13 +96,13 @@ module "aci_useg_endpoint_group" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.15.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.15.0 |
 
 ## Inputs
 
@@ -123,6 +133,7 @@ module "aci_useg_endpoint_group" {
 | <a name="input_match_type"></a> [match\_type](#input\_match\_type) | Match type for IP type uSeg Attributes | `string` | `"any"` | no |
 | <a name="input_ip_statements"></a> [ip\_statements](#input\_ip\_statements) | IP Statements for IP type uSeg Attributes | <pre>list(object({<br/>    name           = string<br/>    use_epg_subnet = bool<br/>    ip             = optional(string, "")<br/>  }))</pre> | `[]` | no |
 | <a name="input_mac_statements"></a> [mac\_statements](#input\_mac\_statements) | MAC Statements for MAC type uSeg Attributes | <pre>list(object({<br/>    name = string<br/>    mac  = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_vm_statements"></a> [vm\_statements](#input\_vm\_statements) | VM Statements for VM type uSeg Attributes | <pre>list(object({<br/>    name     = string<br/>    type     = optional(string, "vm-name")<br/>    operator = optional(string, "equals")<br/>    value    = string<br/>    category = optional(string, "")<br/>    label    = optional(string, "")<br/>  }))</pre> | `[]` | no |
 | <a name="input_l4l7_address_pools"></a> [l4l7\_address\_pools](#input\_l4l7\_address\_pools) | List of EPG L4/L7 Address Pools. | <pre>list(object({<br/>    name            = string<br/>    gateway_address = string<br/>    from            = optional(string, "")<br/>    to              = optional(string, "")<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
@@ -160,6 +171,7 @@ module "aci_useg_endpoint_group" {
 | [aci_rest_managed.fvRsVmmVSwitchEnhancedLagPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvSubnet](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvUplinkOrderCont](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.fvVmAttr](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.fvnsUcastAddrBlk](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.ipNexthopEpP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.tagInst](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-useg-endpoint-group/examples/complete/README.md
+++ b/modules/terraform-aci-useg-endpoint-group/examples/complete/README.md
@@ -58,6 +58,16 @@ module "aci_useg_endpoint_group" {
     name = "mac_2"
     mac  = "02:aa:68:22:58:d2"
   }]
+
+  vm_statements = [{
+    name  = "vm_name"
+    value = "BackEnd"
+    }, {
+    name  = "operating_system"
+    value = "Win11"
+    type  = "guest-os"
+  }]
+
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.2.2.1/24"

--- a/modules/terraform-aci-useg-endpoint-group/examples/complete/main.tf
+++ b/modules/terraform-aci-useg-endpoint-group/examples/complete/main.tf
@@ -44,6 +44,16 @@ module "aci_useg_endpoint_group" {
     name = "mac_2"
     mac  = "02:aa:68:22:58:d2"
   }]
+
+  vm_statements = [{
+    name  = "vm_name"
+    value = "BackEnd"
+    }, {
+    name  = "operating_system"
+    value = "Win11"
+    type  = "guest-os"
+  }]
+
   subnets = [{
     description        = "Subnet Description"
     ip                 = "1.2.2.1/24"

--- a/modules/terraform-aci-useg-endpoint-group/examples/complete/versions.tf
+++ b/modules/terraform-aci-useg-endpoint-group/examples/complete/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.0.0"
+      version = ">= 2.15.0"
     }
   }
 }

--- a/modules/terraform-aci-useg-endpoint-group/main.tf
+++ b/modules/terraform-aci-useg-endpoint-group/main.tf
@@ -87,6 +87,24 @@ resource "aci_rest_managed" "fvMacAttr" {
   ]
 }
 
+resource "aci_rest_managed" "fvVmAttr" {
+  for_each   = { for vm_statement in var.vm_statements : vm_statement.name => vm_statement }
+  dn         = "${aci_rest_managed.fvAEPg.dn}/crtrn/vmattr-${each.value.name}"
+  class_name = "fvVmAttr"
+  content = {
+    operator  = each.value.operator
+    type      = each.value.type
+    value     = each.value.value
+    category  = each.value.category
+    labelName = each.value.label
+    name      = each.value.name
+  }
+
+  depends_on = [
+    aci_rest_managed.fvCrtrn
+  ]
+}
+
 resource "aci_rest_managed" "fvSubnet" {
   for_each   = { for subnet in var.subnets : subnet.ip => subnet }
   dn         = "${aci_rest_managed.fvAEPg.dn}/subnet-[${each.value.ip}]"

--- a/modules/terraform-aci-useg-endpoint-group/variables.tf
+++ b/modules/terraform-aci-useg-endpoint-group/variables.tf
@@ -378,6 +378,40 @@ variable "mac_statements" {
   }
 }
 
+variable "vm_statements" {
+  description = "VM Statements for VM type uSeg Attributes"
+  type = list(object({
+    name     = string
+    type     = optional(string, "vm-name")
+    operator = optional(string, "equals")
+    value    = string
+    category = optional(string, "")
+    label    = optional(string, "")
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for vm_statement in var.vm_statements : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", vm_statement.name))
+    ])
+    error_message = "`name`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for vm_statement in var.vm_statements : try(contains(["vm-name", "guest-os", "hv", "vm", "vnic", "domain", "rootContName", "custom-label", "tag", "vm-folder", "vmfolder-path"], vm_statement.type), false) || try(tonumber(vm_statement.type) >= 0 && tonumber(vm_statement.type) <= 10, false)
+    ])
+    error_message = "`type`: Allowed values are `vm-name`, `guest-os`, `hv`, `vm`, `vnic`, `domain`, `rootContName`, `custom-label`, `tag`, `vm-folder`, `vmfolder-path` or a number between 0 and 10."
+  }
+
+  validation {
+    condition = alltrue([
+      for vm_statement in var.vm_statements : try(contains(["equals", "contains", "startsWith", "endsWith", "notEquals"], vm_statement.operator), false) || try(tonumber(vm_statement.operator) >= 0 && tonumber(vm_statement.operator) <= 4, false)
+    ])
+    error_message = "`operator`: Allowed values are `equals`, `contains`, `startsWith`, `endsWith`, `notEquals` or a number between 0 and 4."
+  }
+}
+
 variable "l4l7_address_pools" {
   description = "List of EPG L4/L7 Address Pools."
   type = list(object({

--- a/modules/terraform-aci-useg-endpoint-group/versions.tf
+++ b/modules/terraform-aci-useg-endpoint-group/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.0.0"
+      version = ">= 2.15.0"
     }
   }
 }


### PR DESCRIPTION
Potential fix for [Issue 93](https://github.com/netascode/terraform-aci-nac-aci/issues/93).

Note: `vm_statement.name` is not displayed in the Web GUI, thus, no `name_suffix` support was added.