### PR TITLE
netascode#271_forwarding_scale_policy

### DIFF
--- a/modules/terraform-aci-forwarding-scale-policy/README.md
+++ b/modules/terraform-aci-forwarding-scale-policy/README.md
@@ -36,7 +36,7 @@ module "aci_forwarding_scale_policy" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Forwarding scale policy name. | `string` | n/a | yes |
-| <a name="input_profile"></a> [profile](#input\_profile) | Profile. Choices: `dual-stack`, `ipv4`, `high-dual-stack`, `high-lpm`. | `string` | `"dual-stack"` | no |
+| <a name="input_profile"></a> [profile](#input\_profile) | Profile. Choices: `dual-stack`, `ipv4`, `high-dual-stack`, `high-lpm`, `high-policy`, `high-ipv4-ep`, `mcast-heavy`, `max-lpm`. | `string` | `"dual-stack"` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-forwarding-scale-policy/variables.tf
+++ b/modules/terraform-aci-forwarding-scale-policy/variables.tf
@@ -9,12 +9,12 @@ variable "name" {
 }
 
 variable "profile" {
-  description = "Profile. Choices: `dual-stack`, `ipv4`, `high-dual-stack`, `high-lpm`."
+  description = "Profile. Choices: `dual-stack`, `ipv4`, `high-dual-stack`, `high-lpm`, `high-policy`, `high-ipv4-ep`, `mcast-heavy`, `max-lpm`."
   type        = string
   default     = "dual-stack"
 
   validation {
-    condition     = contains(["dual-stack", "ipv4", "high-dual-stack", "high-lpm"], var.profile)
-    error_message = "Valid values are `dual-stack`, `ipv4`, `high-dual-stack` or `high-lpm`."
+    condition     = contains(["dual-stack", "ipv4", "high-dual-stack", "high-lpm", "high-policy", "high-ipv4-ep", "mcast-heavy", "max-lpm"], var.profile)
+    error_message = "Valid values are `dual-stack`, `ipv4`, `high-dual-stack`, `high-lpm`, `high-policy`, `high-ipv4-ep`, `mcast-heavy`  or `max-lpm`."
   }
 }


### PR DESCRIPTION
Description
This pull request introduces additional attributes under forwarding scale policy to the existing feature:

high-policy
high-ipv4-ep
mcast-heavy
max-lpm

Motivation
The addition of new attributes under forwarding scale policy

Related Issues
https://github.com/netascode/terraform-aci-nac-aci/issues/271

Configuration example
APIC GUI>> Navigate to Fabric > Access Policies >>Expand Policies > Switch in the left pane.
Right-click Forwarding Scale Profile, then select Create Forwarding Scale Profile Policy.
To apply the policy
Go to Fabric > Access Policies, then Switches > Leaf Switches.
Under Policy Groups, create an access switch policy group and select your newly created forwarding scale profile.