### PR TITLE
issue701 fix for l4l7 logical_interface unique ID

### DIFF
--- a/modules/terraform-aci-l4l7-device/main.tf
+++ b/modules/terraform-aci-l4l7-device/main.tf
@@ -22,7 +22,7 @@ locals {
   logical_iface_concrete_iface = flatten([
     for logical_iface in var.logical_interfaces : [
       for concrete_iface in lookup(logical_iface, "concrete_interfaces", []) : {
-        id             = "${logical_iface.name}-${concrete_iface.interface}"
+        id             = "${logical_iface.name}-${concrete_iface.device}-${concrete_iface.interface}"
         logical_iface  = logical_iface.name
         concrete_iface = concrete_iface.interface
         device         = concrete_iface.device


### PR DESCRIPTION
There is an issue with generating ID for logical_interface. Fix is to improve ID by adding concrete_interface device into ID string:
```
---
apic:
  tenants:
    - name: 'l4l7'
      services:
        l4l7_devices:
          - name: PBR_FW
            service_type: FW
            physical_domain: phy_dom
            concrete_devices:
              - name: PBR_FW-A
                interfaces:
                  #id PBR_FW-A-PBR
                  - name: PBR
                    node_id: 101
                    node2_id: 102
                    channel: ipg-vpc-firewall_fw-a
              - name: PBR_FW-B
                interfaces:
                  #id PBR_FW-B-PBR
                  - name: PBR
                    node_id: 101
                    node2_id: 102
                    channel: ipg-vpc-firewall_fw-b
            logical_interfaces:
              - name: PBR
                vlan: 100
                concrete_interfaces:
                  #id PBR-PBR
                  - device: PBR_FW-A
                    interface_name: PBR
                  #id PBR-PBR <----------------------------- duplicated ID
                  - device: PBR_FW-B
                    interface_name: PBR
```
