### PR TITLE
Access Monitoring Policy Support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,10 @@ repos:
             "./modules/terraform-aci-access-leaf-switch-profile/examples/complete",
           ]
       - id: terraform-docs-system
+        args: ["./modules/terraform-aci-access-monitoring-policy"]
+      - id: terraform-docs-system
+        args: ["./modules/terraform-aci-access-monitoring-policy/examples/complete"]
+      - id: terraform-docs-system
         args: ["./modules/terraform-aci-access-span-destination-group"]
       - id: terraform-docs-system
         args:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Additional example repositories:
 | <a name="module_aci_access_leaf_switch_policy_group"></a> [aci\_access\_leaf\_switch\_policy\_group](#module\_aci\_access\_leaf\_switch\_policy\_group) | ./modules/terraform-aci-access-leaf-switch-policy-group | n/a |
 | <a name="module_aci_access_leaf_switch_profile_auto"></a> [aci\_access\_leaf\_switch\_profile\_auto](#module\_aci\_access\_leaf\_switch\_profile\_auto) | ./modules/terraform-aci-access-leaf-switch-profile | n/a |
 | <a name="module_aci_access_leaf_switch_profile_manual"></a> [aci\_access\_leaf\_switch\_profile\_manual](#module\_aci\_access\_leaf\_switch\_profile\_manual) | ./modules/terraform-aci-access-leaf-switch-profile | n/a |
+| <a name="module_aci_access_monitoring_policy"></a> [aci\_access\_monitoring\_policy](#module\_aci\_access\_monitoring\_policy) | ./modules/terraform-aci-access-monitoring-policy | n/a |
 | <a name="module_aci_access_span_destination_group"></a> [aci\_access\_span\_destination\_group](#module\_aci\_access\_span\_destination\_group) | ./modules/terraform-aci-access-span-destination-group | n/a |
 | <a name="module_aci_access_span_filter_group"></a> [aci\_access\_span\_filter\_group](#module\_aci\_access\_span\_filter\_group) | ./modules/terraform-aci-access-span-filter-group | n/a |
 | <a name="module_aci_access_span_source_group"></a> [aci\_access\_span\_source\_group](#module\_aci\_access\_span\_source\_group) | ./modules/terraform-aci-access-span-source-group | n/a |

--- a/aci_access_policies.tf
+++ b/aci_access_policies.tf
@@ -1025,3 +1025,51 @@ module "aci_netflow_record" {
   description      = try(each.value.description, "")
   match_parameters = try(each.value.match_parameters, [])
 }
+
+locals {
+  access_monitoring_policy = flatten([
+    for policy in try(local.access_policies.monitoring.policies, []) : {
+      key         = format("%s", policy.name)
+      name        = "${policy.name}${local.defaults.apic.access_policies.monitoring.policies.name_suffix}"
+      description = try(policy.description, "")
+      snmp_trap_policies = [for snmp_policy in try(policy.snmp_traps, []) : {
+        name              = "${snmp_policy.name}${local.defaults.apic.access_policies.monitoring.policies.snmp_traps.name_suffix}"
+        destination_group = try("${snmp_policy.destination_group}${local.defaults.apic.fabric_policies.monitoring.snmp_traps.name_suffix}", null)
+      }]
+      syslog_policies = [for syslog_policy in try(policy.syslogs, []) : {
+        name              = "${syslog_policy.name}${local.defaults.apic.access_policies.monitoring.policies.syslogs.name_suffix}"
+        audit             = try(syslog_policy.audit, local.defaults.apic.access_policies.monitoring.policies.syslogs.audit)
+        events            = try(syslog_policy.events, local.defaults.apic.access_policies.monitoring.policies.syslogs.events)
+        faults            = try(syslog_policy.faults, local.defaults.apic.access_policies.monitoring.policies.syslogs.faults)
+        session           = try(syslog_policy.session, local.defaults.apic.access_policies.monitoring.policies.syslogs.session)
+        minimum_severity  = try(syslog_policy.minimum_severity, local.defaults.apic.access_policies.monitoring.policies.syslogs.minimum_severity)
+        destination_group = try("${syslog_policy.destination_group}${local.defaults.apic.fabric_policies.monitoring.syslogs.name_suffix}", null)
+      }]
+      fault_severity_policies = [for fault_policy in try(policy.fault_severity_policies, []) : {
+        class = fault_policy.class
+        faults = [for fault in try(fault_policy.faults, []) : {
+          fault_id         = fault.fault_id
+          initial_severity = try(fault.initial_severity, local.defaults.apic.access_policies.monitoring.policies.fault_severity_policies.initial_severity)
+          target_severity  = try(fault.target_severity, local.defaults.apic.access_policies.monitoring.policies.fault_severity_policies.target_severity)
+          description      = try(fault.description, "")
+        }]
+      }]
+    }
+  ])
+}
+
+module "aci_access_monitoring_policy" {
+  source   = "./modules/terraform-aci-access-monitoring-policy"
+  for_each = { for pol in local.access_monitoring_policy : pol.key => pol if local.modules.aci_access_monitoring_policy && var.manage_access_policies }
+
+  name                    = each.value.name
+  description             = each.value.description
+  snmp_trap_policies      = each.value.snmp_trap_policies
+  syslog_policies         = each.value.syslog_policies
+  fault_severity_policies = each.value.fault_severity_policies
+
+  depends_on = [
+    module.aci_snmp_trap_policy,
+    module.aci_syslog_policy,
+  ]
+}

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -777,6 +777,21 @@ defaults:
             direction: both
             access_paths:
               module: 1
+      monitoring:
+          policies:
+            name_suffix: ""
+            snmp_traps:
+              name_suffix: ""
+            syslogs:
+              name_suffix: ""
+              audit: true
+              events: true
+              faults: true
+              session: false
+              minimum_severity: warnings
+            fault_severity_policies:
+              initial_severity: inherit
+              target_severity: inherit
     node_policies:
       oob_endpoint_group: default
       inb_endpoint_group: default

--- a/defaults/modules.yaml
+++ b/defaults/modules.yaml
@@ -112,6 +112,7 @@ modules:
   aci_mcp: true
   aci_mcp_policy: true
   aci_monitoring_policy: true
+  aci_access_monitoring_policy: true
   aci_mpls_custom_qos_policy: true
   aci_mst_policy: true
   aci_multicast_route_map: true

--- a/modules/terraform-aci-access-monitoring-policy/.terraform-docs.yml
+++ b/modules/terraform-aci-access-monitoring-policy/.terraform-docs.yml
@@ -1,0 +1,34 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Terraform ACI Access Monitoring Policy Module
+
+  Manages ACI Access Monitoring Policy
+
+  Location in GUI:
+  `Fabric` » `Access Policies` » `Policies` » `Monitoring` » `XXX`
+
+  ## Examples
+
+  ```hcl
+  {{ include "./examples/complete/main.tf" }}
+  ```
+
+  {{ .Requirements }}
+
+  {{ .Providers }}
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Resources }}
+
+output:
+  file: README.md
+  mode: replace
+
+sort:
+  enabled: false

--- a/modules/terraform-aci-access-monitoring-policy/README.md
+++ b/modules/terraform-aci-access-monitoring-policy/README.md
@@ -1,0 +1,83 @@
+<!-- BEGIN_TF_DOCS -->
+# Terraform ACI Access Monitoring Policy Module
+
+Manages ACI Access Monitoring Policy
+
+Location in GUI:
+`Fabric` » `Access Policies` » `Policies` » `Monitoring` » `XXX`
+
+## Examples
+
+```hcl
+module "aci_access_monitoring_policy" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-access-monitoring-policy"
+  version = "> 1.0.1"
+
+  name = "test_mon_pol"
+  snmp_trap_policies = [{
+    name              = "test_trap"
+    destination_group = "DAR"
+  }]
+  syslog_policies = [{
+    name              = "test_syslog"
+    audit             = false
+    events            = false
+    faults            = true
+    session           = false
+    minimum_severity  = "alerts"
+    destination_group = "syslog_grp"
+  }]
+  fault_severity_policies = [{
+    class = "l1PhysIf"
+    faults = [{
+      fault_id         = "F1696"
+      initial_severity = "warning"
+      target_severity  = "inherit"
+      description      = "test"
+    }]
+  }]
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.5.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | Access monitoring policy name. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | Description. | `string` | `""` | no |
+| <a name="input_snmp_trap_policies"></a> [snmp\_trap\_policies](#input\_snmp\_trap\_policies) | List of SNMP trap policies. | <pre>list(object({<br/>    name              = string<br/>    destination_group = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_syslog_policies"></a> [syslog\_policies](#input\_syslog\_policies) | List of syslog policies. Default value `audit`: true. Default value `events`: true. Default value `faults`: true. Default value `session`: false. Default value `minimum_severity`: `warnings`. | <pre>list(object({<br/>    name              = string<br/>    audit             = optional(bool, true)<br/>    events            = optional(bool, true)<br/>    faults            = optional(bool, true)<br/>    session           = optional(bool, false)<br/>    minimum_severity  = optional(string, "warnings")<br/>    destination_group = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_fault_severity_policies"></a> [fault\_severity\_policies](#input\_fault\_severity\_policies) | List of fault severity policies. | <pre>list(object({<br/>    class = string<br/>    faults = list(object({<br/>      fault_id         = string<br/>      initial_severity = optional(string, "inherit")<br/>      target_severity  = optional(string, "inherit")<br/>      description      = optional(string, "")<br/>    }))<br/>  }))</pre> | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dn"></a> [dn](#output\_dn) | Distinguished name of `monInfraPol` object. |
+| <a name="output_name"></a> [name](#output\_name) | Access monitoring policy name. |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aci_rest_managed.faultSevAsnP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.monInfraPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.monInfraTarget](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.snmpRsDestGroup](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.snmpSrc](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.syslogRsDestGroup](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.syslogSrc](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-access-monitoring-policy/examples/complete/.terraform-docs.yml
+++ b/modules/terraform-aci-access-monitoring-policy/examples/complete/.terraform-docs.yml
@@ -1,0 +1,24 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Access Monitoring Policy Example
+
+  To run this example you need to execute:
+
+  ```bash
+  $ terraform init
+  $ terraform plan
+  $ terraform apply
+  ```
+
+  Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+  ```hcl
+  {{ include "./main.tf" }}
+  ```
+
+output:
+  file: README.md
+  mode: replace

--- a/modules/terraform-aci-access-monitoring-policy/examples/complete/README.md
+++ b/modules/terraform-aci-access-monitoring-policy/examples/complete/README.md
@@ -1,0 +1,44 @@
+<!-- BEGIN_TF_DOCS -->
+# Access Monitoring Policy Example
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+```hcl
+module "aci_access_monitoring_policy" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-access-monitoring-policy"
+  version = "> 1.0.1"
+
+  name = "test_mon_pol"
+  snmp_trap_policies = [{
+    name              = "test_trap"
+    destination_group = "DAR"
+  }]
+  syslog_policies = [{
+    name              = "test_syslog"
+    audit             = false
+    events            = false
+    faults            = true
+    session           = false
+    minimum_severity  = "alerts"
+    destination_group = "syslog_grp"
+  }]
+  fault_severity_policies = [{
+    class = "l1PhysIf"
+    faults = [{
+      fault_id         = "F1696"
+      initial_severity = "warning"
+      target_severity  = "inherit"
+      description      = "test"
+    }]
+  }]
+}
+```
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-access-monitoring-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-access-monitoring-policy/examples/complete/main.tf
@@ -1,0 +1,28 @@
+module "aci_access_monitoring_policy" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-access-monitoring-policy"
+  version = "> 1.0.1"
+
+  name = "test_mon_pol"
+  snmp_trap_policies = [{
+    name              = "test_trap"
+    destination_group = "DAR"
+  }]
+  syslog_policies = [{
+    name              = "test_syslog"
+    audit             = false
+    events            = false
+    faults            = true
+    session           = false
+    minimum_severity  = "alerts"
+    destination_group = "syslog_grp"
+  }]
+  fault_severity_policies = [{
+    class = "l1PhysIf"
+    faults = [{
+      fault_id         = "F1696"
+      initial_severity = "warning"
+      target_severity  = "inherit"
+      description      = "test"
+    }]
+  }]
+}

--- a/modules/terraform-aci-access-monitoring-policy/examples/complete/versions.tf
+++ b/modules/terraform-aci-access-monitoring-policy/examples/complete/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.5.0"
+    }
+  }
+}

--- a/modules/terraform-aci-access-monitoring-policy/main.tf
+++ b/modules/terraform-aci-access-monitoring-policy/main.tf
@@ -1,0 +1,84 @@
+locals {
+  faults = flatten([
+    for policy in var.fault_severity_policies : [
+      for fault in policy.faults : {
+        class            = policy.class
+        fault_id         = fault.fault_id
+        initial_severity = fault.initial_severity
+        target_severity  = fault.target_severity
+        description      = fault.description
+      }
+    ]
+  ])
+}
+
+resource "aci_rest_managed" "monInfraPol" {
+  dn         = "uni/infra/moninfra-${var.name}"
+  class_name = "monInfraPol"
+  content = {
+    name  = var.name
+    descr = var.description
+  }
+}
+
+# SNMP trap policies
+resource "aci_rest_managed" "snmpSrc" {
+  for_each   = { for snmp in var.snmp_trap_policies : snmp.name => snmp }
+  dn         = "${aci_rest_managed.monInfraPol.dn}/snmpsrc-${each.value.name}"
+  class_name = "snmpSrc"
+  content = {
+    name = each.value.name
+  }
+}
+
+resource "aci_rest_managed" "snmpRsDestGroup" {
+  for_each   = { for snmp in var.snmp_trap_policies : snmp.name => snmp if snmp.destination_group != null }
+  dn         = "${aci_rest_managed.snmpSrc[each.value.name].dn}/rsdestGroup"
+  class_name = "snmpRsDestGroup"
+  content = {
+    tDn = "uni/fabric/snmpgroup-${each.value.destination_group}"
+  }
+}
+
+# Syslog policies  
+resource "aci_rest_managed" "syslogSrc" {
+  for_each   = { for syslog in var.syslog_policies : syslog.name => syslog }
+  dn         = "${aci_rest_managed.monInfraPol.dn}/slsrc-${each.value.name}"
+  class_name = "syslogSrc"
+  content = {
+    name   = each.value.name
+    incl   = join(",", concat(each.value.audit == true && each.value.events == true && each.value.faults == true && each.value.session == true ? ["all"] : [], each.value.audit == true ? ["audit"] : [], each.value.events == true ? ["events"] : [], each.value.faults == true ? ["faults"] : [], each.value.session == true ? ["session"] : []))
+    minSev = each.value.minimum_severity
+  }
+}
+
+resource "aci_rest_managed" "syslogRsDestGroup" {
+  for_each   = { for syslog in var.syslog_policies : syslog.name => syslog if syslog.destination_group != null }
+  dn         = "${aci_rest_managed.syslogSrc[each.value.name].dn}/rsdestGroup"
+  class_name = "syslogRsDestGroup"
+  content = {
+    tDn = "uni/fabric/slgroup-${each.value.destination_group}"
+  }
+}
+
+# Fault severity policies
+resource "aci_rest_managed" "monInfraTarget" {
+  for_each   = { for fsp in var.fault_severity_policies : fsp.class => fsp }
+  dn         = "${aci_rest_managed.monInfraPol.dn}/tarinfra-${each.value.class}"
+  class_name = "monInfraTarget"
+  content = {
+    scope = each.value.class
+  }
+}
+
+resource "aci_rest_managed" "faultSevAsnP" {
+  for_each   = { for f in local.faults : f.fault_id => f }
+  dn         = "${aci_rest_managed.monInfraTarget[each.value.class].dn}/fsevp-${each.value.fault_id}"
+  class_name = "faultSevAsnP"
+  content = {
+    code    = each.value.fault_id
+    initial = each.value.initial_severity
+    target  = each.value.target_severity
+    descr   = each.value.description
+  }
+}

--- a/modules/terraform-aci-access-monitoring-policy/outputs.tf
+++ b/modules/terraform-aci-access-monitoring-policy/outputs.tf
@@ -1,0 +1,9 @@
+output "dn" {
+  description = "Distinguished name of `monInfraPol` object."
+  value       = try(aci_rest_managed.monInfraPol.id, "")
+}
+
+output "name" {
+  description = "Access monitoring policy name."
+  value       = try(aci_rest_managed.monInfraPol.content.name, "")
+}

--- a/modules/terraform-aci-access-monitoring-policy/variables.tf
+++ b/modules/terraform-aci-access-monitoring-policy/variables.tf
@@ -1,0 +1,136 @@
+variable "name" {
+  description = "Access monitoring policy name."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "description" {
+  description = "Description."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9\\!#$%()*,-./:;@ _{|}~?&+]{0,128}$", var.description))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, `}`, `~`, `?`, `&`, `+`. Maximum characters: 128."
+  }
+}
+
+variable "snmp_trap_policies" {
+  description = "List of SNMP trap policies."
+  type = list(object({
+    name              = string
+    destination_group = optional(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for snmp in var.snmp_trap_policies : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", snmp.name))
+    ])
+    error_message = "Allowed characters `name`: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for snmp in var.snmp_trap_policies : snmp.destination_group == null || can(regex("^[a-zA-Z0-9_.:-]{0,64}$", snmp.destination_group))
+    ])
+    error_message = "Allowed characters `destination_group`: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "syslog_policies" {
+  description = "List of syslog policies. Default value `audit`: true. Default value `events`: true. Default value `faults`: true. Default value `session`: false. Default value `minimum_severity`: `warnings`."
+  type = list(object({
+    name              = string
+    audit             = optional(bool, true)
+    events            = optional(bool, true)
+    faults            = optional(bool, true)
+    session           = optional(bool, false)
+    minimum_severity  = optional(string, "warnings")
+    destination_group = optional(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for syslog in var.syslog_policies : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", syslog.name))
+    ])
+    error_message = "Allowed characters `name`: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue([
+      for syslog in var.syslog_policies : contains(["emergencies", "alerts", "critical", "errors", "warnings", "notifications", "information", "debugging"], syslog.minimum_severity)
+    ])
+    error_message = "`minimum_severity`: Allowed values are `emergencies`, `alerts`, `critical`, `errors`, `warnings`, `notifications`, `information` or `debugging`."
+  }
+
+  validation {
+    condition = alltrue([
+      for syslog in var.syslog_policies : syslog.destination_group == null || can(regex("^[a-zA-Z0-9_.:-]{0,64}$", syslog.destination_group))
+    ])
+    error_message = "Allowed characters `destination_group`: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "fault_severity_policies" {
+  description = "List of fault severity policies."
+  type = list(object({
+    class = string
+    faults = list(object({
+      fault_id         = string
+      initial_severity = optional(string, "inherit")
+      target_severity  = optional(string, "inherit")
+      description      = optional(string, "")
+    }))
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for policy in var.fault_severity_policies : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", policy.class))
+    ])
+    error_message = "Allowed characters `class`: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Required `pkg+className`.Maximum characters: 64."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for policy in var.fault_severity_policies : [
+        for fault in policy.faults : fault.description == null || try(can(regex("^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]{0,128}$", fault.description)), false)
+      ]
+    ]))
+    error_message = "`faults.description`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, `}`, `~`, `?`, `&`, `+`. Maximum characters: 128."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for policy in var.fault_severity_policies : [
+        for fault in policy.faults : contains(["warning", "minor", "major", "critical", "inherit", "squelched"], fault.initial_severity)
+      ]
+    ]))
+    error_message = "`initial_severity`: Allowed values are `warning`, `minor`, `major`, `critical`, `inherit` or `squelched`."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for policy in var.fault_severity_policies : [
+        for fault in policy.faults : contains(["warning", "minor", "major", "critical", "inherit"], fault.target_severity)
+      ]
+    ]))
+    error_message = "`target_severity`: Allowed values are `warning`, `minor`, `major`, `critical` or `inherit`."
+  }
+  validation {
+    condition = alltrue(flatten([
+      for policy in var.fault_severity_policies : [
+        for fault in policy.faults : fault.initial_severity == "squelched" || index(["warning", "minor", "major", "critical", "inherit"], fault.target_severity) >= index(["warning", "minor", "major", "critical", "inherit", "squelched"], fault.initial_severity)
+      ]
+    ]))
+    error_message = "`target_severity` level must be equal or higher than `initial_severity` level."
+  }
+
+}
+

--- a/modules/terraform-aci-access-monitoring-policy/versions.tf
+++ b/modules/terraform-aci-access-monitoring-policy/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.5.0"
+    }
+  }
+}


### PR DESCRIPTION
Description

This pull request introduces introduces support for the access monitoring policy:

Pre-Existing Files (new section added to support the new feature):
*defaults/defaults.yaml

Motivation

The feature allows to create the object for the Access Monitoring Policy. This feature has been introduced internally, so adding support for terraform.

Related Issues

Issue https://wwwin-github.cisco.com/netascode/nac-aci/issues/455 in the ACI as Code Planning backlog