### PR TITLE
'config_passphrase' min length set to 16.

### DIFF
--- a/modules/terraform-aci-config-passphrase/variables.tf
+++ b/modules/terraform-aci-config-passphrase/variables.tf
@@ -4,7 +4,7 @@ variable "config_passphrase" {
   sensitive   = true
 
   validation {
-    condition     = can(regex("^.{0,32}$", var.config_passphrase))
-    error_message = "Maximum characters: 32."
+    condition     = can(regex("^.{16,32}$", var.config_passphrase))
+    error_message = "Allowed characters: any. Minimum characters: 16. Maximum characters: 32."
   }
 }


### PR DESCRIPTION
`config_passphrase` min length set to 16.

The APIC uses a 16 to 32 character passphrase to generate the AES-256 keys. [Source](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/aci/apic/sw/kb/b_KB_Using_Import_Export_to_Recover_Config_States.html)