### PR TITLE
fixed macOs null value handling in contains() function

### DIFF
--- a/modules/terraform-aci-ip-sla-policy/variables.tf
+++ b/modules/terraform-aci-ip-sla-policy/variables.tf
@@ -79,7 +79,7 @@ variable "http_method" {
   default     = null
 
   validation {
-    condition     = var.http_method == null || can(contains(["get"], var.http_method))
+    condition     = var.http_method == null ? true : contains(["get"], var.http_method)
     error_message = "Valid values are `get`."
   }
 }
@@ -90,7 +90,7 @@ variable "http_version" {
   default     = null
 
   validation {
-    condition     = var.http_version == null || can(contains(["HTTP10", "HTTP11"], var.http_version))
+    condition     = var.http_version == null ? true : contains(["HTTP10", "HTTP11"], var.http_version)
     error_message = "Valid values are `HTTP10` or `HTTP11`."
   }
 }

--- a/modules/terraform-aci-vrf/variables.tf
+++ b/modules/terraform-aci-vrf/variables.tf
@@ -57,7 +57,7 @@ variable "enforcement_direction" {
   default     = null
 
   validation {
-    condition     = var.enforcement_direction == null || can(contains(["ingress", "egress"], var.enforcement_direction))
+    condition     = var.enforcement_direction == null ? true : contains(["ingress", "egress"], var.enforcement_direction)
     error_message = "Valid values are `ingress` or `egress`."
   }
 }


### PR DESCRIPTION
fixed null value handling for vrf enforcement_direction, http_method and http_version