### PR TITLE
Add support for Filter > match_only_fragments

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -1715,6 +1715,7 @@ locals {
           destination_from_port = try(entry.destination_from_port, local.defaults.apic.tenants.filters.entries.destination_from_port)
           destination_to_port   = try(entry.destination_to_port, entry.destination_from_port, local.defaults.apic.tenants.filters.entries.destination_from_port)
           stateful              = try(entry.stateful, local.defaults.apic.tenants.filters.entries.stateful)
+          match_only_fragments  = try(entry.match_only_fragments, local.defaults.apic.tenants.filters.entries.match_only_fragments)
         }]
       }
     ]

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1365,6 +1365,7 @@ defaults:
           source_from_port: unspecified
           destination_from_port: unspecified
           stateful: false
+          match_only_fragments: false
       policies:
         custom_qos:
           name_suffix: ""

--- a/modules/terraform-aci-filter/README.md
+++ b/modules/terraform-aci-filter/README.md
@@ -28,6 +28,11 @@ module "aci_filter" {
     destination_from_port = "234"
     destination_to_port   = "235"
     stateful              = true
+    }, {
+    name                 = "ENTRY2"
+    ethertype            = "ipv4"
+    protocol             = "tcp"
+    match_only_fragments = true
   }]
 }
 ```
@@ -53,7 +58,7 @@ module "aci_filter" {
 | <a name="input_name"></a> [name](#input\_name) | Filter name. | `string` | n/a | yes |
 | <a name="input_alias"></a> [alias](#input\_alias) | Filter alias. | `string` | `""` | no |
 | <a name="input_description"></a> [description](#input\_description) | Filter description. | `string` | `""` | no |
-| <a name="input_entries"></a> [entries](#input\_entries) | List of filter entries. Choices `ethertype`: `unspecified`, `ipv4`, `trill`, `arp`, `ipv6`, `mpls_ucast`, `mac_security`, `fcoe`, `ip`. Default value `ethertype`: `ip`. Allowed values `protocol`: `unspecified`, `icmp`, `igmp`, `tcp`, `egp`, `igp`, `udp`, `icmpv6`, `eigrp`, `ospfigp`, `pim`, `l2tp` or a number between 0 and 255. Default value `protocol`: `tcp`. Allowed values `source_from_port`, `source_to_port`, `destination_from_port`, `destination_to_port`: `unspecified`, `dns`, `ftpData`, `http`, `https`, `pop3`, `rtsp`, `smtp`, `ssh` or a number between 0 and 65535. Default value `source_from_port`, `source_to_port`, `destination_from_port`, `destination_to_port`: `unspecified`. Default value `stateful`: false. | <pre>list(object({<br/>    name                  = string<br/>    alias                 = optional(string, "")<br/>    description           = optional(string, "")<br/>    ethertype             = optional(string, "ip")<br/>    protocol              = optional(string, "tcp")<br/>    source_from_port      = optional(string, "unspecified")<br/>    source_to_port        = optional(string, "unspecified")<br/>    destination_from_port = optional(string, "unspecified")<br/>    destination_to_port   = optional(string, "unspecified")<br/>    stateful              = optional(bool, false)<br/>  }))</pre> | `[]` | no |
+| <a name="input_entries"></a> [entries](#input\_entries) | List of filter entries. Choices `ethertype`: `unspecified`, `ipv4`, `trill`, `arp`, `ipv6`, `mpls_ucast`, `mac_security`, `fcoe`, `ip`. Default value `ethertype`: `ip`. Allowed values `protocol`: `unspecified`, `icmp`, `igmp`, `tcp`, `egp`, `igp`, `udp`, `icmpv6`, `eigrp`, `ospfigp`, `pim`, `l2tp` or a number between 0 and 255. Default value `protocol`: `tcp`. Allowed values `source_from_port`, `source_to_port`, `destination_from_port`, `destination_to_port`: `unspecified`, `dns`, `ftpData`, `http`, `https`, `pop3`, `rtsp`, `smtp`, `ssh` or a number between 0 and 65535. Default value `source_from_port`, `source_to_port`, `destination_from_port`, `destination_to_port`: `unspecified`. Default value `stateful`: false. Default value `match_only_fragments`: false. | <pre>list(object({<br/>    name                  = string<br/>    alias                 = optional(string, "")<br/>    description           = optional(string, "")<br/>    ethertype             = optional(string, "ip")<br/>    protocol              = optional(string, "tcp")<br/>    source_from_port      = optional(string, "unspecified")<br/>    source_to_port        = optional(string, "unspecified")<br/>    destination_from_port = optional(string, "unspecified")<br/>    destination_to_port   = optional(string, "unspecified")<br/>    stateful              = optional(bool, false)<br/>    match_only_fragments  = optional(bool, false)<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-filter/examples/complete/README.md
+++ b/modules/terraform-aci-filter/examples/complete/README.md
@@ -31,6 +31,11 @@ module "aci_filter" {
     destination_from_port = "234"
     destination_to_port   = "235"
     stateful              = true
+    }, {
+    name                 = "ENTRY2"
+    ethertype            = "ipv4"
+    protocol             = "tcp"
+    match_only_fragments = true
   }]
 }
 ```

--- a/modules/terraform-aci-filter/examples/complete/main.tf
+++ b/modules/terraform-aci-filter/examples/complete/main.tf
@@ -17,5 +17,10 @@ module "aci_filter" {
     destination_from_port = "234"
     destination_to_port   = "235"
     stateful              = true
+    }, {
+    name                 = "ENTRY2"
+    ethertype            = "ipv4"
+    protocol             = "tcp"
+    match_only_fragments = true
   }]
 }

--- a/modules/terraform-aci-filter/main.tf
+++ b/modules/terraform-aci-filter/main.tf
@@ -13,16 +13,17 @@ resource "aci_rest_managed" "vzEntry" {
   dn         = "${aci_rest_managed.vzFilter.dn}/e-${each.value.name}"
   class_name = "vzEntry"
   content = {
-    name      = each.value.name
-    nameAlias = each.value.alias
-    descr     = each.value.description
-    etherT    = each.value.ethertype
-    prot      = contains(["ip", "ipv4", "ipv6", null], each.value.ethertype) ? (each.value.protocol == "1" ? "icmp" : each.value.protocol == "2" ? "igmp" : each.value.protocol == "6" ? "tcp" : each.value.protocol == "8" ? "egp" : each.value.protocol == "9" ? "igp" : each.value.protocol == "17" ? "udp" : each.value.protocol == "58" ? "icmpv6" : each.value.protocol == "88" ? "eigrp" : each.value.protocol == "89" ? "ospfigp" : each.value.protocol == "103" ? "pim" : each.value.protocol == "115" ? "l2tp" : each.value.protocol) : null
-    sFromPort = each.value.source_from_port == "20" ? "ftpData" : each.value.source_from_port == "22" ? "ssh" : each.value.source_from_port == "25" ? "smtp" : each.value.source_from_port == "53" ? "dns" : each.value.source_from_port == "80" ? "http" : each.value.source_from_port == "110" ? "pop3" : each.value.source_from_port == "443" ? "https" : each.value.source_from_port == "554" ? "rtsp" : each.value.source_from_port
-    sToPort   = each.value.source_to_port == "20" ? "ftpData" : each.value.source_to_port == "22" ? "ssh" : each.value.source_to_port == "25" ? "smtp" : each.value.source_to_port == "53" ? "dns" : each.value.source_to_port == "80" ? "http" : each.value.source_to_port == "110" ? "pop3" : each.value.source_to_port == "443" ? "https" : each.value.source_to_port == "554" ? "rtsp" : each.value.source_to_port
-    dFromPort = each.value.destination_from_port == "20" ? "ftpData" : each.value.destination_from_port == "22" ? "ssh" : each.value.destination_from_port == "25" ? "smtp" : each.value.destination_from_port == "53" ? "dns" : each.value.destination_from_port == "80" ? "http" : each.value.destination_from_port == "110" ? "pop3" : each.value.destination_from_port == "443" ? "https" : each.value.destination_from_port == "554" ? "rtsp" : each.value.destination_from_port
-    dToPort   = each.value.destination_to_port == "20" ? "ftpData" : each.value.destination_to_port == "22" ? "ssh" : each.value.destination_to_port == "25" ? "smtp" : each.value.destination_to_port == "53" ? "dns" : each.value.destination_to_port == "80" ? "http" : each.value.destination_to_port == "110" ? "pop3" : each.value.destination_to_port == "443" ? "https" : each.value.destination_to_port == "554" ? "rtsp" : each.value.destination_to_port
-    stateful  = each.value.stateful == true ? "yes" : "no"
+    name        = each.value.name
+    nameAlias   = each.value.alias
+    descr       = each.value.description
+    etherT      = each.value.ethertype
+    prot        = contains(["ip", "ipv4", "ipv6", null], each.value.ethertype) ? (each.value.protocol == "1" ? "icmp" : each.value.protocol == "2" ? "igmp" : each.value.protocol == "6" ? "tcp" : each.value.protocol == "8" ? "egp" : each.value.protocol == "9" ? "igp" : each.value.protocol == "17" ? "udp" : each.value.protocol == "58" ? "icmpv6" : each.value.protocol == "88" ? "eigrp" : each.value.protocol == "89" ? "ospfigp" : each.value.protocol == "103" ? "pim" : each.value.protocol == "115" ? "l2tp" : each.value.protocol) : null
+    sFromPort   = each.value.source_from_port == "20" ? "ftpData" : each.value.source_from_port == "22" ? "ssh" : each.value.source_from_port == "25" ? "smtp" : each.value.source_from_port == "53" ? "dns" : each.value.source_from_port == "80" ? "http" : each.value.source_from_port == "110" ? "pop3" : each.value.source_from_port == "443" ? "https" : each.value.source_from_port == "554" ? "rtsp" : each.value.source_from_port
+    sToPort     = each.value.source_to_port == "20" ? "ftpData" : each.value.source_to_port == "22" ? "ssh" : each.value.source_to_port == "25" ? "smtp" : each.value.source_to_port == "53" ? "dns" : each.value.source_to_port == "80" ? "http" : each.value.source_to_port == "110" ? "pop3" : each.value.source_to_port == "443" ? "https" : each.value.source_to_port == "554" ? "rtsp" : each.value.source_to_port
+    dFromPort   = each.value.destination_from_port == "20" ? "ftpData" : each.value.destination_from_port == "22" ? "ssh" : each.value.destination_from_port == "25" ? "smtp" : each.value.destination_from_port == "53" ? "dns" : each.value.destination_from_port == "80" ? "http" : each.value.destination_from_port == "110" ? "pop3" : each.value.destination_from_port == "443" ? "https" : each.value.destination_from_port == "554" ? "rtsp" : each.value.destination_from_port
+    dToPort     = each.value.destination_to_port == "20" ? "ftpData" : each.value.destination_to_port == "22" ? "ssh" : each.value.destination_to_port == "25" ? "smtp" : each.value.destination_to_port == "53" ? "dns" : each.value.destination_to_port == "80" ? "http" : each.value.destination_to_port == "110" ? "pop3" : each.value.destination_to_port == "443" ? "https" : each.value.destination_to_port == "554" ? "rtsp" : each.value.destination_to_port
+    stateful    = each.value.stateful == true ? "yes" : "no"
+    applyToFrag = each.value.match_only_fragments == true ? "yes" : "no"
   }
 }
 

--- a/modules/terraform-aci-filter/variables.tf
+++ b/modules/terraform-aci-filter/variables.tf
@@ -41,7 +41,7 @@ variable "description" {
 }
 
 variable "entries" {
-  description = "List of filter entries. Choices `ethertype`: `unspecified`, `ipv4`, `trill`, `arp`, `ipv6`, `mpls_ucast`, `mac_security`, `fcoe`, `ip`. Default value `ethertype`: `ip`. Allowed values `protocol`: `unspecified`, `icmp`, `igmp`, `tcp`, `egp`, `igp`, `udp`, `icmpv6`, `eigrp`, `ospfigp`, `pim`, `l2tp` or a number between 0 and 255. Default value `protocol`: `tcp`. Allowed values `source_from_port`, `source_to_port`, `destination_from_port`, `destination_to_port`: `unspecified`, `dns`, `ftpData`, `http`, `https`, `pop3`, `rtsp`, `smtp`, `ssh` or a number between 0 and 65535. Default value `source_from_port`, `source_to_port`, `destination_from_port`, `destination_to_port`: `unspecified`. Default value `stateful`: false."
+  description = "List of filter entries. Choices `ethertype`: `unspecified`, `ipv4`, `trill`, `arp`, `ipv6`, `mpls_ucast`, `mac_security`, `fcoe`, `ip`. Default value `ethertype`: `ip`. Allowed values `protocol`: `unspecified`, `icmp`, `igmp`, `tcp`, `egp`, `igp`, `udp`, `icmpv6`, `eigrp`, `ospfigp`, `pim`, `l2tp` or a number between 0 and 255. Default value `protocol`: `tcp`. Allowed values `source_from_port`, `source_to_port`, `destination_from_port`, `destination_to_port`: `unspecified`, `dns`, `ftpData`, `http`, `https`, `pop3`, `rtsp`, `smtp`, `ssh` or a number between 0 and 65535. Default value `source_from_port`, `source_to_port`, `destination_from_port`, `destination_to_port`: `unspecified`. Default value `stateful`: false. Default value `match_only_fragments`: false."
   type = list(object({
     name                  = string
     alias                 = optional(string, "")
@@ -53,6 +53,7 @@ variable "entries" {
     destination_from_port = optional(string, "unspecified")
     destination_to_port   = optional(string, "unspecified")
     stateful              = optional(bool, false)
+    match_only_fragments  = optional(bool, false)
   }))
   default = []
 


### PR DESCRIPTION
Add support for `Filter > match_only_fragments` attribute.

When `match_only_fragments` is enabled in GUI, the rest of attributes are grayed-out and it is not possible to define them.