### PR TITLE
## Fix - circular dependency between L3Out, Set Rule ## 

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -1033,7 +1033,6 @@ module "aci_l3out" {
     module.aci_ospf_interface_policy,
     module.aci_eigrp_interface_policy,
     module.aci_bfd_interface_policy,
-    module.aci_set_rule,
     module.aci_match_rule,
   ]
 }
@@ -2750,6 +2749,7 @@ module "aci_set_rule" {
 
   depends_on = [
     module.aci_tenant,
+    module.aci_external_endpoint_group,
   ]
 }
 


### PR DESCRIPTION
Tested with this model 

---
### =============================================================================
### L3Out Circular Dependency Test Configuration (SIMPLIFIED)
### =============================================================================
### Tests the fix for circular dependency between:
###   L3Out → Set Rule (with External EPG option) → External EPG → L3Out
#
### After the fix, the dependency order should be:
###   L3Out → External EPG → Set Rule (linear, no cycle)
# =============================================================================

apic:
  tenants:
    - name: L3OUT_CIRCULAR_TEST
      description: "Tenant for testing L3Out circular dependency fix"

      vrfs:
        - name: VRF-TEST
          description: "VRF for circular dependency testing"

      l3outs:
        # -----------------------------------------------------------------------
        # SCENARIO 1: Basic - Original Issue Reproduction
        # Set Rule with external_endpoint_group pointing to same L3Out's EPG
        # -----------------------------------------------------------------------
        - name: L3OUT-BASIC
          description: "Scenario 1: Basic circular dependency test"
          vrf: VRF-TEST
          domain: L3DOM-TEST
          external_endpoint_groups:
            - name: EEPG-BASIC
              description: "External EPG for basic test"
              subnets:
                - prefix: 0.0.0.0/0
                  scope:
                    - import-security
          import_route_map:
            type: combinable
            contexts:
              - name: CTX-BASIC-IMPORT
                order: 1
                match_rules:
                  - MR-ALL-PREFIXES
                set_rule: SR-BASIC
          nodes:
            - node_id: 101
              router_id: 10.1.1.1

        ### -----------------------------------------------------------------------
        ### SCENARIO 2: Multiple External EPGs with Set Rules (IMPORT ONLY)
        ### -----------------------------------------------------------------------
        - name: L3OUT-MULTIPLE
          description: "Scenario 2: Multiple EPGs and Set Rules"
          vrf: VRF-TEST
          domain: L3DOM-TEST
          external_endpoint_groups:
            - name: EEPG-INTERNAL
              description: "Internal network EPG"
              subnets:
                - prefix: 10.0.0.0/8
                  scope:
                    - import-security
            - name: EEPG-EXTERNAL
              description: "External network EPG"
              subnets:
                - prefix: 0.0.0.0/0
                  scope:
                    - import-security
          import_route_map:
            type: combinable
            contexts:
              - name: CTX-INTERNAL
                order: 1
                match_rules:
                  - MR-INTERNAL
                set_rule: SR-INTERNAL
              - name: CTX-EXTERNAL
                order: 2
                match_rules:
                  - MR-EXTERNAL
                set_rule: SR-EXTERNAL
          nodes:
            - node_id: 102
              router_id: 10.2.2.2

        ### -----------------------------------------------------------------------
        ### SCENARIO 3: Cross-L3Out Reference
        ### Set Rule in one L3Out references External EPG in different L3Out
        ### -----------------------------------------------------------------------
        - name: L3OUT-CROSS-SOURCE
          description: "Scenario 3: Cross-L3Out - Source L3Out"
          vrf: VRF-TEST
          domain: L3DOM-TEST
          external_endpoint_groups:
            - name: EEPG-SOURCE
              description: "Source network EPG"
              subnets:
                - prefix: 192.168.0.0/16
                  scope:
                    - import-security
          import_route_map:
            type: combinable
            contexts:
              - name: CTX-CROSS-REF
                order: 1
                match_rules:
                  - MR-ALL-PREFIXES
                # This set rule references EPG in L3OUT-CROSS-TARGET
                set_rule: SR-CROSS-L3OUT
          nodes:
            - node_id: 103
              router_id: 10.3.3.1

        - name: L3OUT-CROSS-TARGET
          description: "Scenario 3: Cross-L3Out - Target L3Out"
          vrf: VRF-TEST
          domain: L3DOM-TEST
          external_endpoint_groups:
            - name: EEPG-TARGET
              description: "Target network EPG - referenced by SR-CROSS-L3OUT"
              subnets:
                - prefix: 10.10.0.0/16
                  scope:
                    - import-security
          nodes:
            - node_id: 104
              router_id: 10.3.3.2

      ### =========================================================================
      ### POLICIES SECTION
      ### =========================================================================
      policies:
        match_rules:
          - name: MR-ALL-PREFIXES
            description: "Match all prefixes"
            prefixes:
              - ip: 0.0.0.0/0
                aggregate: true

          - name: MR-INTERNAL
            description: "Match internal prefixes"
            prefixes:
              - ip: 10.0.0.0/8

          - name: MR-EXTERNAL
            description: "Match external prefixes"
            prefixes:
              - ip: 0.0.0.0/0

        ### -----------------------------------------------------------------------
        ### Set Rules with external_endpoint_group references
        ### These are the key objects testing the circular dependency fix
        ### -----------------------------------------------------------------------
        set_rules:
          # Scenario 1: Basic - References EPG in same L3Out
          - name: SR-BASIC
            description: "Scenario 1: Set Rule for basic test"
            tag: 100
            external_endpoint_group:
              name: EEPG-BASIC
              l3out: L3OUT-BASIC
              tenant: L3OUT_CIRCULAR_TEST

          # Scenario 2: Multiple Set Rules (IMPORT ONLY)
          - name: SR-INTERNAL
            description: "Scenario 2: Set Rule for internal traffic"
            tag: 201
            external_endpoint_group:
              name: EEPG-INTERNAL
              l3out: L3OUT-MULTIPLE
              tenant: L3OUT_CIRCULAR_TEST

          - name: SR-EXTERNAL
            description: "Scenario 2: Set Rule for external traffic"
            tag: 202
            preference: 100
            external_endpoint_group:
              name: EEPG-EXTERNAL
              l3out: L3OUT-MULTIPLE
              tenant: L3OUT_CIRCULAR_TEST

          # Scenario 3: Cross-L3Out reference
          - name: SR-CROSS-L3OUT
            description: "Scenario 3: Set Rule referencing EPG in different L3Out"
            tag: 300
            external_endpoint_group:
              name: EEPG-TARGET
              l3out: L3OUT-CROSS-TARGET
              tenant: L3OUT_CIRCULAR_TEST

          # Control test: Set Rule WITHOUT external_endpoint_group reference
          - name: SR-NO-EPG-REFERENCE
            description: "Control: Set Rule without EPG reference"
            tag: 999
            metric: 100
