### PR TITLE
Changing the data model link in the README.md to the correct one

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -26,7 +26,7 @@ content: |-
   - `interface_policies`: Configurations applied at the interface level (e.g., assigning interface policy groups to physical ports)
   - `tenants`: Configurations applied at the tenant level (e.g., VRFs and Bridge Domains)
 
-  The full data model documentation is available here: https://netascode.cisco.com/data_model/overview
+  The full data model documentation is available here: https://netascode.cisco.com/docs/data_models/apic/overview/ 
 
   ## Examples
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are six configuration sections which can be selectively enabled or disable
 - `interface_policies`: Configurations applied at the interface level (e.g., assigning interface policy groups to physical ports)
 - `tenants`: Configurations applied at the tenant level (e.g., VRFs and Bridge Domains)
 
-The full data model documentation is available here: https://netascode.cisco.com/data_model/overview
+The full data model documentation is available here: https://netascode.cisco.com/docs/data_models/apic/overview/ 
 
 ## Examples
 


### PR DESCRIPTION
i took the liberty to fix the issue #359 

Changed the data model link to to the https://netascode.cisco.com/docs/data_models/apic/overview/ link

