### PR TITLE
Add support for ap_leaf_interface_policy_group > port_channel_member_name

### DIFF
--- a/aci_access_policies.tf
+++ b/aci_access_policies.tf
@@ -490,6 +490,7 @@ module "aci_access_leaf_interface_policy_group" {
   l2_policy                          = try("${each.value.l2_policy}${local.defaults.apic.access_policies.interface_policies.l2_policies.name_suffix}", "")
   storm_control_policy               = try("${each.value.storm_control_policy}${local.defaults.apic.access_policies.interface_policies.storm_control_policies.name_suffix}", "")
   port_channel_policy                = try("${each.value.port_channel_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_policies.name_suffix}", "")
+  port_channel_member_name           = try(each.value.port_channel_member_name, "${each.value.name}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}")
   port_channel_member_policy         = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
   netflow_monitor_policies = [for monitor in try(each.value.netflow_monitor_policies, []) : {
     name           = "${monitor.name}${local.defaults.apic.access_policies.interface_policies.netflow_monitors.name_suffix}"

--- a/modules/terraform-aci-access-leaf-interface-policy-group/README.md
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/README.md
@@ -25,6 +25,7 @@ module "aci_access_leaf_interface_policy_group" {
   l2_policy                  = "PORT-LOCAL"
   storm_control_policy       = "10P"
   port_channel_policy        = "LACP"
+  port_channel_member_name   = "PG-Member"
   port_channel_member_policy = "FAST"
   aaep                       = "AAEP1"
 }
@@ -62,6 +63,7 @@ module "aci_access_leaf_interface_policy_group" {
 | <a name="input_l2_policy"></a> [l2\_policy](#input\_l2\_policy) | L2 policy name. | `string` | `""` | no |
 | <a name="input_storm_control_policy"></a> [storm\_control\_policy](#input\_storm\_control\_policy) | Storm control policy name. | `string` | `""` | no |
 | <a name="input_port_channel_policy"></a> [port\_channel\_policy](#input\_port\_channel\_policy) | Port channel policy name. | `string` | `""` | no |
+| <a name="input_port_channel_member_name"></a> [port\_channel\_member\_name](#input\_port\_channel\_member\_name) | Port channel member name. | `string` | `""` | no |
 | <a name="input_port_channel_member_policy"></a> [port\_channel\_member\_policy](#input\_port\_channel\_member\_policy) | Port channel member policy name. | `string` | `""` | no |
 | <a name="input_aaep"></a> [aaep](#input\_aaep) | Attachable access entity profile name. | `string` | `""` | no |
 | <a name="input_netflow_monitor_policies"></a> [netflow\_monitor\_policies](#input\_netflow\_monitor\_policies) | List of Netflow Monitor policies. Choices `ip_filter_type`: `ipv4, `ipv6`, `ce`, `unspecified`.` | <pre>list(object({<br/>    name           = string<br/>    ip_filter_type = optional(string, "ipv4")<br/>  }))</pre> | `[]` | no |

--- a/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/README.md
@@ -28,6 +28,7 @@ module "aci_access_leaf_interface_policy_group" {
   l2_policy                  = "PORT-LOCAL"
   storm_control_policy       = "10P"
   port_channel_policy        = "LACP"
+  port_channel_member_name   = "PG-Member"
   port_channel_member_policy = "FAST"
   aaep                       = "AAEP1"
 }

--- a/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/main.tf
@@ -14,6 +14,7 @@ module "aci_access_leaf_interface_policy_group" {
   l2_policy                  = "PORT-LOCAL"
   storm_control_policy       = "10P"
   port_channel_policy        = "LACP"
+  port_channel_member_name   = "PG-Member"
   port_channel_member_policy = "FAST"
   aaep                       = "AAEP1"
 }

--- a/modules/terraform-aci-access-leaf-interface-policy-group/main.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/main.tf
@@ -110,10 +110,10 @@ resource "aci_rest_managed" "infraRsLacpPol" {
 
 resource "aci_rest_managed" "infraAccBndlSubgrp" {
   count      = (var.type == "vpc" || var.type == "pc") && var.port_channel_member_policy != "" ? 1 : 0
-  dn         = "${aci_rest_managed.infraAccGrp.dn}/accsubbndl-${var.name}"
+  dn         = "${aci_rest_managed.infraAccGrp.dn}/accsubbndl-${var.port_channel_member_name}"
   class_name = "infraAccBndlSubgrp"
   content = {
-    name = var.name
+    name = var.port_channel_member_name
   }
 }
 

--- a/modules/terraform-aci-access-leaf-interface-policy-group/variables.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/variables.tf
@@ -163,6 +163,17 @@ variable "port_channel_policy" {
   }
 }
 
+variable "port_channel_member_name" {
+  description = "Port channel member name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.port_channel_member_name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
 variable "port_channel_member_policy" {
   description = "Port channel member policy name."
   type        = string


### PR DESCRIPTION
Backwards compatibility is verified, no breaking change.