### PR TITLE
Bug - Undesired SNMP Context creation

### DIFF
--- a/modules/terraform-aci-vrf/main.tf
+++ b/modules/terraform-aci-vrf/main.tf
@@ -72,6 +72,7 @@ resource "aci_rest_managed" "fvCtx" {
 }
 
 resource "aci_rest_managed" "snmpCtxP" {
+  count      = var.snmp_context_name != null && var.snmp_context_name != "" ? 1 : 0
   dn         = "${aci_rest_managed.fvCtx.dn}/snmpctx"
   class_name = "snmpCtxP"
   content = {
@@ -81,7 +82,7 @@ resource "aci_rest_managed" "snmpCtxP" {
 
 resource "aci_rest_managed" "snmpCommunityP" {
   for_each   = { for comm_profile in var.snmp_context_community_profiles : comm_profile.name => comm_profile }
-  dn         = "${aci_rest_managed.snmpCtxP.dn}/community-${each.value.name}"
+  dn         = "${aci_rest_managed.snmpCtxP[0].dn}/community-${each.value.name}"
   class_name = "snmpCommunityP"
   content = {
     "name"  = each.value.name


### PR DESCRIPTION
Description

This pull request introduces a fix in the terraform-aci-vrf module that created an empty SNMP Context.

-Motivation

When a new VRF is created using terraform, the module automatically created an SNMP Context even when the input yaml files does not define any context. This PR introduces some checks in the resource to check whether the definition exists or not.
