### PR TITLE
Fix incorrect metric and preference values in aci_set_rules

### DIFF
--- a/modules/terraform-aci-set-rule/variables.tf
+++ b/modules/terraform-aci-set-rule/variables.tf
@@ -129,7 +129,7 @@ variable "preference" {
   default     = null
 
   validation {
-    condition     = coalesce(var.preference, 0) >= 0 && coalesce(var.preference, 65535) <= 65535
+    condition     = coalesce(var.preference, 0) >= 0 && coalesce(var.preference, 4294967295) <= 4294967295
     error_message = "Minimum value: `0`. Maximum value: `4294967295`."
   }
 }
@@ -140,7 +140,7 @@ variable "metric" {
   default     = null
 
   validation {
-    condition     = coalesce(var.metric, 0) >= 0 && coalesce(var.metric, 65535) <= 65535
+    condition     = coalesce(var.metric, 0) >= 0 && coalesce(var.metric, 4294967295) <= 4294967295
     error_message = "Minimum value: `0`. Maximum value: `4294967295`."
   }
 }


### PR DESCRIPTION
`preference` and `metric` fields for set rules should have a max value of 4294967295. This is already reflected in the JSON schema and the validation error_message is incorrectly set to 65535 in the validation logic. This PR updates the max value to the higher value.