### PR TITLE
Add support for SG Templates multi-nodes

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -4049,24 +4049,49 @@ locals {
   service_graph_templates = flatten([
     for tenant in local.tenants : [
       for sgt in try(tenant.services.service_graph_templates, []) : {
-        key                     = format("%s/%s", tenant.name, sgt.name)
-        tenant                  = tenant.name
-        name                    = "${sgt.name}${local.defaults.apic.tenants.services.service_graph_templates.name_suffix}"
-        annotation              = try(sgt.ndo_managed, local.defaults.apic.tenants.services.service_graph_templates.ndo_managed) ? "orchestrator:msc-shadow:no" : null
-        description             = try(sgt.description, "")
-        alias                   = try(sgt.alias, "")
-        template_type           = try(sgt.template_type, local.defaults.apic.tenants.services.service_graph_templates.template_type)
-        redirect                = try(sgt.redirect, local.defaults.apic.tenants.services.service_graph_templates.redirect)
-        share_encapsulation     = try(sgt.share_encapsulation, local.defaults.apic.tenants.services.service_graph_templates.share_encapsulation)
-        device_name             = "${sgt.device.name}${local.defaults.apic.tenants.services.l4l7_devices.name_suffix}"
+        key                 = format("%s/%s", tenant.name, sgt.name)
+        tenant              = tenant.name
+        name                = "${sgt.name}${local.defaults.apic.tenants.services.service_graph_templates.name_suffix}"
+        annotation          = try(sgt.ndo_managed, local.defaults.apic.tenants.services.service_graph_templates.ndo_managed) ? "orchestrator:msc-shadow:no" : null
+        description         = try(sgt.description, "")
+        alias               = try(sgt.alias, "")
+        template_type       = try(sgt.template_type, local.defaults.apic.tenants.services.service_graph_templates.template_type)
+        redirect            = try(sgt.redirect, local.defaults.apic.tenants.services.service_graph_templates.redirect)
+        share_encapsulation = try(sgt.share_encapsulation, local.defaults.apic.tenants.services.service_graph_templates.share_encapsulation)
+        # Legacy single-device mode fields (only used when sgt.device is defined and sgt.devices is not)
+        device_name             = try("${sgt.device.name}${local.defaults.apic.tenants.services.l4l7_devices.name_suffix}", "")
         device_tenant           = try(sgt.device.tenant, tenant.name)
-        device_function         = length([for d in local.l4l7_devices : d if d.tenant == try(sgt.device.tenant, tenant.name)]) > 0 ? [for device in local.l4l7_devices : try(device.function, local.defaults.apic.tenants.services.l4l7_devices.function) if device.name == sgt.device.name && (device.tenant == try(sgt.device.tenant, tenant.name))][0] : local.defaults.apic.tenants.services.l4l7_devices.function
-        device_copy             = length([for d in local.l4l7_devices : d if d.tenant == try(sgt.device.tenant, tenant.name)]) > 0 ? [for device in local.l4l7_devices : try(device.copy_device, local.defaults.apic.tenants.services.l4l7_devices.copy_device) if device.name == sgt.device.name && (device.tenant == try(sgt.device.tenant, tenant.name))][0] : local.defaults.apic.tenants.services.l4l7_devices.copy_device
-        device_managed          = length([for d in local.l4l7_devices : d if d.tenant == try(sgt.device.tenant, tenant.name)]) > 0 ? [for device in local.l4l7_devices : try(device.managed, local.defaults.apic.tenants.services.l4l7_devices.managed) if device.name == sgt.device.name && (device.tenant == try(sgt.device.tenant, tenant.name))][0] : local.defaults.apic.tenants.services.l4l7_devices.managed
-        device_node_name        = (length([for d in local.l4l7_devices : d if d.tenant == try(sgt.device.tenant, tenant.name)]) > 0 ? [for device in local.l4l7_devices : try(device.copy_device, local.defaults.apic.tenants.services.l4l7_devices.copy_device) if device.name == sgt.device.name && (device.tenant == try(sgt.device.tenant, tenant.name))][0] : false) == true ? try(sgt.device.node_name, "CP1") : try(sgt.device.node_name, "N1")
+        device_function         = try(sgt.device, null) != null && length([for d in local.l4l7_devices : d if d.tenant == try(sgt.device.tenant, tenant.name)]) > 0 ? [for device in local.l4l7_devices : try(device.function, local.defaults.apic.tenants.services.l4l7_devices.function) if device.name == sgt.device.name && (device.tenant == try(sgt.device.tenant, tenant.name))][0] : local.defaults.apic.tenants.services.l4l7_devices.function
+        device_copy             = try(sgt.device, null) != null && length([for d in local.l4l7_devices : d if d.tenant == try(sgt.device.tenant, tenant.name)]) > 0 ? [for device in local.l4l7_devices : try(device.copy_device, local.defaults.apic.tenants.services.l4l7_devices.copy_device) if device.name == sgt.device.name && (device.tenant == try(sgt.device.tenant, tenant.name))][0] : local.defaults.apic.tenants.services.l4l7_devices.copy_device
+        device_managed          = try(sgt.device, null) != null && length([for d in local.l4l7_devices : d if d.tenant == try(sgt.device.tenant, tenant.name)]) > 0 ? [for device in local.l4l7_devices : try(device.managed, local.defaults.apic.tenants.services.l4l7_devices.managed) if device.name == sgt.device.name && (device.tenant == try(sgt.device.tenant, tenant.name))][0] : local.defaults.apic.tenants.services.l4l7_devices.managed
+        device_node_name        = try(sgt.device, null) != null ? ((try(sgt.device, null) != null && length([for d in local.l4l7_devices : d if d.tenant == try(sgt.device.tenant, tenant.name)]) > 0 ? [for device in local.l4l7_devices : try(device.copy_device, local.defaults.apic.tenants.services.l4l7_devices.copy_device) if device.name == sgt.device.name && (device.tenant == try(sgt.device.tenant, tenant.name))][0] : false) == true ? try(sgt.device.node_name, "CP1") : try(sgt.device.node_name, "N1")) : "N1"
         device_adjacency_type   = try(sgt.device.adjacency_type, local.defaults.apic.tenants.services.service_graph_templates.device.adjacency_type)
         consumer_direct_connect = try(sgt.consumer.direct_connect, local.defaults.apic.tenants.services.service_graph_templates.consumer.direct_connect)
         provider_direct_connect = try(sgt.provider.direct_connect, local.defaults.apic.tenants.services.service_graph_templates.provider.direct_connect)
+        # Multi-device mode Devices
+        devices = try(sgt.devices, null) != null ? [
+          for device in sgt.devices : {
+            name          = "${device.name}${local.defaults.apic.tenants.services.l4l7_devices.name_suffix}"
+            tenant        = try(device.tenant, tenant.name)
+            node_name     = try(device.node_name, null)
+            template_type = try(device.template_type, null)
+            # Look up Device properties from l4l7_devices
+            function    = length([for d in local.l4l7_devices : d if d.name == device.name && d.tenant == try(device.tenant, tenant.name)]) > 0 ? [for d in local.l4l7_devices : try(d.function, local.defaults.apic.tenants.services.l4l7_devices.function) if d.name == device.name && d.tenant == try(device.tenant, tenant.name)][0] : local.defaults.apic.tenants.services.l4l7_devices.function
+            copy_device = length([for d in local.l4l7_devices : d if d.name == device.name && d.tenant == try(device.tenant, tenant.name)]) > 0 ? [for d in local.l4l7_devices : try(d.copy_device, local.defaults.apic.tenants.services.l4l7_devices.copy_device) if d.name == device.name && d.tenant == try(device.tenant, tenant.name)][0] : local.defaults.apic.tenants.services.l4l7_devices.copy_device
+            managed     = length([for d in local.l4l7_devices : d if d.name == device.name && d.tenant == try(device.tenant, tenant.name)]) > 0 ? [for d in local.l4l7_devices : try(d.managed, local.defaults.apic.tenants.services.l4l7_devices.managed) if d.name == device.name && d.tenant == try(device.tenant, tenant.name)][0] : local.defaults.apic.tenants.services.l4l7_devices.managed
+          }
+        ] : []
+        # Multi-device mode Connections
+        connections = try(sgt.connections, null) != null ? [
+          for conn in sgt.connections : {
+            consumer_node  = conn.consumer_node
+            provider_node  = conn.provider_node
+            copy_node      = try(conn.copy_node, null)
+            adjacency_type = try(conn.adjacency_type, local.defaults.apic.tenants.services.service_graph_templates.connections.adjacency_type)
+            unicast_route  = try(conn.unicast_route, local.defaults.apic.tenants.services.service_graph_templates.connections.unicast_route)
+            direct_connect = try(conn.direct_connect, local.defaults.apic.tenants.services.service_graph_templates.connections.direct_connect)
+          }
+        ] : []
       }
     ]
   ])
@@ -4093,6 +4118,8 @@ module "aci_service_graph_template" {
   device_adjacency_type   = each.value.device_adjacency_type
   consumer_direct_connect = each.value.consumer_direct_connect
   provider_direct_connect = each.value.provider_direct_connect
+  devices                 = each.value.devices
+  connections             = each.value.connections
 
   depends_on = [
     module.aci_tenant,

--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -4074,7 +4074,7 @@ locals {
             name          = "${device.name}${local.defaults.apic.tenants.services.l4l7_devices.name_suffix}"
             tenant        = try(device.tenant, tenant.name)
             node_name     = try(device.node_name, null)
-            template_type = try(device.template_type, null)
+            template_type = try(device.template_type, sgt.template_type, local.defaults.apic.tenants.services.service_graph_templates.devices.template_type)
             # Look up Device properties from l4l7_devices
             function    = length([for d in local.l4l7_devices : d if d.name == device.name && d.tenant == try(device.tenant, tenant.name)]) > 0 ? [for d in local.l4l7_devices : try(d.function, local.defaults.apic.tenants.services.l4l7_devices.function) if d.name == device.name && d.tenant == try(device.tenant, tenant.name)][0] : local.defaults.apic.tenants.services.l4l7_devices.function
             copy_device = length([for d in local.l4l7_devices : d if d.name == device.name && d.tenant == try(device.tenant, tenant.name)]) > 0 ? [for d in local.l4l7_devices : try(d.copy_device, local.defaults.apic.tenants.services.l4l7_devices.copy_device) if d.name == device.name && d.tenant == try(device.tenant, tenant.name)][0] : local.defaults.apic.tenants.services.l4l7_devices.copy_device

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1845,6 +1845,12 @@ defaults:
             direct_connect: false
           device:
             adjacency_type: "L3"
+          connections:
+            adjacency_type: "L2"
+            unicast_route: true
+            direct_connect: false
+          devices:
+            template_type: OTHER
         device_selection_policies:
           consumer:
             l3_destination: true

--- a/modules/terraform-aci-service-graph-template/README.md
+++ b/modules/terraform-aci-service-graph-template/README.md
@@ -34,7 +34,7 @@ module "aci_service_graph_template" {
 # Multi-device mode example with explicit devices and connections
 module "aci_service_graph_template_multi" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
-  version = ">= 0.8.0"
+  version = "> 1.2.0"
 
   tenant              = "ABC"
   name                = "SGT_MULTI"

--- a/modules/terraform-aci-service-graph-template/README.md
+++ b/modules/terraform-aci-service-graph-template/README.md
@@ -9,6 +9,7 @@ Location in GUI:
 ## Examples
 
 ```hcl
+# Legacy single-device mode example
 module "aci_service_graph_template" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
   version = ">= 0.8.0"
@@ -28,6 +29,68 @@ module "aci_service_graph_template" {
   device_adjacency_type   = "L2"
   consumer_direct_connect = false
   provider_direct_connect = true
+}
+
+# Multi-device mode example with explicit devices and connections
+module "aci_service_graph_template_multi" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
+  version = ">= 0.8.0"
+
+  tenant              = "ABC"
+  name                = "SGT_MULTI"
+  description         = "Multi-device service graph template"
+  template_type       = "FW_ROUTED"
+  redirect            = true
+  share_encapsulation = false
+
+  devices = [
+    {
+      name          = "FW1"
+      node_name     = "FIREWALL"
+      template_type = "FW_ROUTED"
+      function      = "GoTo"
+      copy_device   = false
+      managed       = false
+    },
+    {
+      name        = "LB1"
+      node_name   = "LOADBALANCER"
+      tenant      = "DEF"
+      copy_device = false
+      managed     = false
+    },
+    {
+      name        = "TAP1"
+      node_name   = "COPY_DEVICE"
+      copy_device = true
+      managed     = false
+    }
+  ]
+
+  connections = [
+    {
+      consumer_node  = "EPG-Consumer"
+      provider_node  = "FW1"
+      copy_node      = "TAP1"
+      adjacency_type = "L3"
+      unicast_route  = true
+      direct_connect = false
+    },
+    {
+      consumer_node  = "FW1"
+      provider_node  = "LB1"
+      adjacency_type = "L2"
+      unicast_route  = false
+      direct_connect = false
+    },
+    {
+      consumer_node  = "LB1"
+      provider_node  = "EPG-Provider"
+      adjacency_type = "L3"
+      unicast_route  = true
+      direct_connect = true
+    }
+  ]
 }
 ```
 
@@ -56,7 +119,7 @@ module "aci_service_graph_template" {
 | <a name="input_template_type"></a> [template\_type](#input\_template\_type) | Template type. Choices: `FW_TRANS`, `FW_ROUTED`, `ADC_ONE_ARM`, `ADC_TWO_ARM`, `OTHER`, `CLOUD_NATIVE_LB`, `CLOUD_VENDOR_LB`, `CLOUD_NATIVE_FW`, `CLOUD_VENDOR_FW`. | `string` | `"OTHER"` | no |
 | <a name="input_redirect"></a> [redirect](#input\_redirect) | Redirect. | `bool` | `false` | no |
 | <a name="input_share_encapsulation"></a> [share\_encapsulation](#input\_share\_encapsulation) | Share encapsulation. | `bool` | `false` | no |
-| <a name="input_device_name"></a> [device\_name](#input\_device\_name) | L4L7 device name. | `string` | n/a | yes |
+| <a name="input_device_name"></a> [device\_name](#input\_device\_name) | L4L7 device name. Required for legacy single-device mode, not used when `devices` is specified. | `string` | `""` | no |
 | <a name="input_device_tenant"></a> [device\_tenant](#input\_device\_tenant) | L4L7 device tenant name. | `string` | `""` | no |
 | <a name="input_device_function"></a> [device\_function](#input\_device\_function) | L4L7 device function. Choices: `None`, `GoTo`, `GoThrough`, `L2`, `L1`. | `string` | `"GoTo"` | no |
 | <a name="input_device_copy"></a> [device\_copy](#input\_device\_copy) | L4L7 device copy function. | `bool` | `false` | no |
@@ -65,6 +128,8 @@ module "aci_service_graph_template" {
 | <a name="input_device_adjacency_type"></a> [device\_adjacency\_type](#input\_device\_adjacency\_type) | L4L7 device adjacency type. Choices: `L2`, `L3`. Default is `L3`. | `string` | `"L3"` | no |
 | <a name="input_consumer_direct_connect"></a> [consumer\_direct\_connect](#input\_consumer\_direct\_connect) | Direct connect on consumer connection. | `bool` | `false` | no |
 | <a name="input_provider_direct_connect"></a> [provider\_direct\_connect](#input\_provider\_direct\_connect) | Direct connect on provider connection. | `bool` | `false` | no |
+| <a name="input_devices"></a> [devices](#input\_devices) | List of devices for multi-device service graph. When specified, legacy device variables are ignored. | <pre>list(object({<br/>    name          = string<br/>    tenant        = optional(string)<br/>    node_name     = optional(string)<br/>    template_type = optional(string)<br/>    function      = optional(string)<br/>    copy_device   = optional(bool)<br/>    managed       = optional(bool)<br/>  }))</pre> | `[]` | no |
+| <a name="input_connections"></a> [connections](#input\_connections) | List of connections for multi-device service graph. | <pre>list(object({<br/>    consumer_node  = string<br/>    provider_node  = string<br/>    copy_node      = optional(string)<br/>    adjacency_type = optional(string)<br/>    unicast_route  = optional(bool)<br/>    direct_connect = optional(bool)<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
 
@@ -79,11 +144,16 @@ module "aci_service_graph_template" {
 |------|------|
 | [aci_rest_managed.vnsAbsConnection_Consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsConnection_Provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsAbsConnection_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsFuncConn_Consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsAbsFuncConn_Consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsFuncConn_Copy](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsAbsFuncConn_Copy_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsFuncConn_Provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsAbsFuncConn_Provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsGraph](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsNode](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsAbsNode_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsTermConn_T1](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsTermConn_T2](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsAbsTermNodeCon](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
@@ -97,7 +167,11 @@ module "aci_service_graph_template" {
 | [aci_rest_managed.vnsRsAbsConnectionConns_ConT1CP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsAbsConnectionConns_ConT2](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsAbsConnectionConns_ConT2CP](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsAbsConnectionConns_Consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsAbsConnectionConns_NodeN1Consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsAbsConnectionConns_NodeN1Provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsAbsConnectionConns_Provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsAbsCopyConnection_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsNodeToLDev](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsNodeToLDev_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-service-graph-template/examples/complete/README.md
+++ b/modules/terraform-aci-service-graph-template/examples/complete/README.md
@@ -37,7 +37,7 @@ module "aci_service_graph_template" {
 # Multi-device mode example with explicit devices and connections
 module "aci_service_graph_template_multi" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
-  version = ">= 0.8.0"
+  version = "> 1.2.0"
 
   tenant              = "ABC"
   name                = "SGT_MULTI"

--- a/modules/terraform-aci-service-graph-template/examples/complete/README.md
+++ b/modules/terraform-aci-service-graph-template/examples/complete/README.md
@@ -12,6 +12,7 @@ $ terraform apply
 Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
 
 ```hcl
+# Legacy single-device mode example
 module "aci_service_graph_template" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
   version = ">= 0.8.0"
@@ -31,6 +32,68 @@ module "aci_service_graph_template" {
   device_adjacency_type   = "L2"
   consumer_direct_connect = false
   provider_direct_connect = true
+}
+
+# Multi-device mode example with explicit devices and connections
+module "aci_service_graph_template_multi" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
+  version = ">= 0.8.0"
+
+  tenant              = "ABC"
+  name                = "SGT_MULTI"
+  description         = "Multi-device service graph template"
+  template_type       = "FW_ROUTED"
+  redirect            = true
+  share_encapsulation = false
+
+  devices = [
+    {
+      name          = "FW1"
+      node_name     = "FIREWALL"
+      template_type = "FW_ROUTED"
+      function      = "GoTo"
+      copy_device   = false
+      managed       = false
+    },
+    {
+      name        = "LB1"
+      node_name   = "LOADBALANCER"
+      tenant      = "DEF"
+      copy_device = false
+      managed     = false
+    },
+    {
+      name        = "TAP1"
+      node_name   = "COPY_DEVICE"
+      copy_device = true
+      managed     = false
+    }
+  ]
+
+  connections = [
+    {
+      consumer_node  = "EPG-Consumer"
+      provider_node  = "FW1"
+      copy_node      = "TAP1"
+      adjacency_type = "L3"
+      unicast_route  = true
+      direct_connect = false
+    },
+    {
+      consumer_node  = "FW1"
+      provider_node  = "LB1"
+      adjacency_type = "L2"
+      unicast_route  = false
+      direct_connect = false
+    },
+    {
+      consumer_node  = "LB1"
+      provider_node  = "EPG-Provider"
+      adjacency_type = "L3"
+      unicast_route  = true
+      direct_connect = true
+    }
+  ]
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-service-graph-template/examples/complete/main.tf
+++ b/modules/terraform-aci-service-graph-template/examples/complete/main.tf
@@ -23,7 +23,7 @@ module "aci_service_graph_template" {
 # Multi-device mode example with explicit devices and connections
 module "aci_service_graph_template_multi" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
-  version = ">= 0.8.0"
+  version = "> 1.2.0"
 
   tenant              = "ABC"
   name                = "SGT_MULTI"

--- a/modules/terraform-aci-service-graph-template/examples/complete/main.tf
+++ b/modules/terraform-aci-service-graph-template/examples/complete/main.tf
@@ -1,3 +1,4 @@
+# Legacy single-device mode example
 module "aci_service_graph_template" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
   version = ">= 0.8.0"
@@ -17,4 +18,66 @@ module "aci_service_graph_template" {
   device_adjacency_type   = "L2"
   consumer_direct_connect = false
   provider_direct_connect = true
+}
+
+# Multi-device mode example with explicit devices and connections
+module "aci_service_graph_template_multi" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-service-graph-template"
+  version = ">= 0.8.0"
+
+  tenant              = "ABC"
+  name                = "SGT_MULTI"
+  description         = "Multi-device service graph template"
+  template_type       = "FW_ROUTED"
+  redirect            = true
+  share_encapsulation = false
+
+  devices = [
+    {
+      name          = "FW1"
+      node_name     = "FIREWALL"
+      template_type = "FW_ROUTED"
+      function      = "GoTo"
+      copy_device   = false
+      managed       = false
+    },
+    {
+      name        = "LB1"
+      node_name   = "LOADBALANCER"
+      tenant      = "DEF"
+      copy_device = false
+      managed     = false
+    },
+    {
+      name        = "TAP1"
+      node_name   = "COPY_DEVICE"
+      copy_device = true
+      managed     = false
+    }
+  ]
+
+  connections = [
+    {
+      consumer_node  = "EPG-Consumer"
+      provider_node  = "FW1"
+      copy_node      = "TAP1"
+      adjacency_type = "L3"
+      unicast_route  = true
+      direct_connect = false
+    },
+    {
+      consumer_node  = "FW1"
+      provider_node  = "LB1"
+      adjacency_type = "L2"
+      unicast_route  = false
+      direct_connect = false
+    },
+    {
+      consumer_node  = "LB1"
+      provider_node  = "EPG-Provider"
+      adjacency_type = "L3"
+      unicast_route  = true
+      direct_connect = true
+    }
+  ]
 }

--- a/modules/terraform-aci-service-graph-template/main.tf
+++ b/modules/terraform-aci-service-graph-template/main.tf
@@ -1,3 +1,36 @@
+locals {
+  multi_device_mode = length(var.devices) > 0
+
+  devices_map = {
+    for idx, device in var.devices : device.name => {
+      index         = idx
+      name          = device.name
+      tenant        = coalesce(device.tenant, var.tenant)
+      node_name     = coalesce(device.node_name, device.name)
+      template_type = coalesce(device.template_type, var.template_type)
+      function      = coalesce(device.function, "GoTo")
+      copy_device   = coalesce(device.copy_device, false)
+      managed       = coalesce(device.managed, false)
+    }
+  }
+
+  connections_map = {
+    for idx, conn in var.connections : "C${idx + 1}" => {
+      index                  = idx
+      name                   = "C${idx + 1}"
+      consumer_node          = conn.consumer_node
+      provider_node          = conn.provider_node
+      copy_node              = conn.copy_node
+      adjacency_type         = coalesce(conn.adjacency_type, "L2")
+      unicast_route          = coalesce(conn.unicast_route, true)
+      direct_connect         = coalesce(conn.direct_connect, false)
+      resolved_consumer_node = conn.consumer_node == "EPG-Consumer" ? "EPG-Consumer" : try(local.devices_map[conn.consumer_node].node_name, conn.consumer_node)
+      resolved_provider_node = conn.provider_node == "EPG-Provider" ? "EPG-Provider" : try(local.devices_map[conn.provider_node].node_name, conn.provider_node)
+      resolved_copy_node     = conn.copy_node != null ? try(local.devices_map[conn.copy_node].node_name, conn.copy_node) : null
+    }
+  }
+}
+
 resource "aci_rest_managed" "vnsAbsGraph" {
   dn         = "uni/tn-${var.tenant}/AbsGraph-${var.name}"
   class_name = "vnsAbsGraph"
@@ -72,6 +105,7 @@ resource "aci_rest_managed" "vnsOutTerm_T2" {
 }
 
 resource "aci_rest_managed" "vnsAbsNode" {
+  count      = local.multi_device_mode ? 0 : 1
   dn         = "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${var.device_node_name}"
   class_name = "vnsAbsNode"
   annotation = var.annotation
@@ -88,8 +122,8 @@ resource "aci_rest_managed" "vnsAbsNode" {
 }
 
 resource "aci_rest_managed" "vnsAbsFuncConn_Provider" {
-  count      = var.device_copy ? 0 : 1
-  dn         = "${aci_rest_managed.vnsAbsNode.dn}/AbsFConn-provider"
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 0 : 1)
+  dn         = "${aci_rest_managed.vnsAbsNode[0].dn}/AbsFConn-provider"
   class_name = "vnsAbsFuncConn"
   annotation = var.annotation
   content = {
@@ -99,8 +133,8 @@ resource "aci_rest_managed" "vnsAbsFuncConn_Provider" {
 }
 
 resource "aci_rest_managed" "vnsAbsFuncConn_Consumer" {
-  count      = var.device_copy ? 0 : 1
-  dn         = "${aci_rest_managed.vnsAbsNode.dn}/AbsFConn-consumer"
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 0 : 1)
+  dn         = "${aci_rest_managed.vnsAbsNode[0].dn}/AbsFConn-consumer"
   class_name = "vnsAbsFuncConn"
   annotation = var.annotation
   content = {
@@ -110,8 +144,8 @@ resource "aci_rest_managed" "vnsAbsFuncConn_Consumer" {
 }
 
 resource "aci_rest_managed" "vnsAbsFuncConn_Copy" {
-  count      = var.device_copy ? 1 : 0
-  dn         = "${aci_rest_managed.vnsAbsNode.dn}/AbsFConn-copy"
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 1 : 0)
+  dn         = "${aci_rest_managed.vnsAbsNode[0].dn}/AbsFConn-copy"
   class_name = "vnsAbsFuncConn"
   content = {
     attNotify = "no"
@@ -120,7 +154,8 @@ resource "aci_rest_managed" "vnsAbsFuncConn_Copy" {
 }
 
 resource "aci_rest_managed" "vnsRsNodeToLDev" {
-  dn         = "${aci_rest_managed.vnsAbsNode.dn}/rsNodeToLDev"
+  count      = local.multi_device_mode ? 0 : 1
+  dn         = "${aci_rest_managed.vnsAbsNode[0].dn}/rsNodeToLDev"
   class_name = "vnsRsNodeToLDev"
   annotation = var.annotation != null ? "" : null
   content = {
@@ -129,6 +164,7 @@ resource "aci_rest_managed" "vnsRsNodeToLDev" {
 }
 
 resource "aci_rest_managed" "vnsAbsConnection_Consumer" {
+  count      = local.multi_device_mode ? 0 : 1
   dn         = "${aci_rest_managed.vnsAbsGraph.dn}/AbsConnection-C1"
   class_name = "vnsAbsConnection"
   annotation = var.annotation
@@ -143,8 +179,8 @@ resource "aci_rest_managed" "vnsAbsConnection_Consumer" {
 }
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConT1" {
-  count      = var.device_copy ? 0 : 1
-  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer.dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]"
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 0 : 1)
+  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer[0].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]"
   class_name = "vnsRsAbsConnectionConns"
   annotation = var.annotation
   content = {
@@ -153,8 +189,8 @@ resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConT1" {
 }
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_NodeN1Consumer" {
-  count      = var.device_copy ? 0 : 1
-  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer.dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsFuncConn_Consumer[0].dn}]" # index added
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 0 : 1)
+  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer[0].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsFuncConn_Consumer[0].dn}]"
   class_name = "vnsRsAbsConnectionConns"
   annotation = var.annotation
   content = {
@@ -163,7 +199,7 @@ resource "aci_rest_managed" "vnsRsAbsConnectionConns_NodeN1Consumer" {
 }
 
 resource "aci_rest_managed" "vnsAbsConnection_Provider" {
-  count      = var.device_copy ? 0 : 1
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 0 : 1)
   dn         = "${aci_rest_managed.vnsAbsGraph.dn}/AbsConnection-C2"
   class_name = "vnsAbsConnection"
   annotation = var.annotation
@@ -178,7 +214,7 @@ resource "aci_rest_managed" "vnsAbsConnection_Provider" {
 }
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConT2" {
-  count      = var.device_copy ? 0 : 1
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 0 : 1)
   dn         = "${aci_rest_managed.vnsAbsConnection_Provider[0].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T2.dn}]"
   class_name = "vnsRsAbsConnectionConns"
   annotation = var.annotation
@@ -188,8 +224,8 @@ resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConT2" {
 }
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_NodeN1Provider" {
-  count      = var.device_copy ? 0 : 1
-  dn         = "${aci_rest_managed.vnsAbsConnection_Provider[0].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsFuncConn_Provider[0].dn}]" # index added
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 0 : 1)
+  dn         = "${aci_rest_managed.vnsAbsConnection_Provider[0].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsFuncConn_Provider[0].dn}]"
   class_name = "vnsRsAbsConnectionConns"
   annotation = var.annotation
   content = {
@@ -198,8 +234,8 @@ resource "aci_rest_managed" "vnsRsAbsConnectionConns_NodeN1Provider" {
 }
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConCP1" {
-  count      = var.device_copy ? 1 : 0
-  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer.dn}/rsabsCopyConnection-[${aci_rest_managed.vnsAbsFuncConn_Copy[0].dn}]"
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 1 : 0)
+  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer[0].dn}/rsabsCopyConnection-[${aci_rest_managed.vnsAbsFuncConn_Copy[0].dn}]"
   class_name = "vnsRsAbsCopyConnection"
   content = {
     tDn = aci_rest_managed.vnsAbsFuncConn_Copy[0].dn
@@ -207,8 +243,8 @@ resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConCP1" {
 }
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConT1CP" {
-  count      = var.device_copy ? 1 : 0
-  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer.dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]"
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 1 : 0)
+  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer[0].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]"
   class_name = "vnsRsAbsConnectionConns"
   content = {
     tDn = aci_rest_managed.vnsAbsTermConn_T1.dn
@@ -219,13 +255,124 @@ resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConT1CP" {
 }
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_ConT2CP" {
-  count      = var.device_copy ? 1 : 0
-  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer.dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T2.dn}]"
+  count      = local.multi_device_mode ? 0 : (var.device_copy ? 1 : 0)
+  dn         = "${aci_rest_managed.vnsAbsConnection_Consumer[0].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T2.dn}]"
   class_name = "vnsRsAbsConnectionConns"
   content = {
     tDn = aci_rest_managed.vnsAbsTermConn_T2.dn
   }
   depends_on = [
     aci_rest_managed.vnsRsAbsConnectionConns_ConCP1
+  ]
+}
+
+resource "aci_rest_managed" "vnsAbsNode_multi" {
+  for_each   = local.multi_device_mode ? local.devices_map : {}
+  dn         = "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.node_name}"
+  class_name = "vnsAbsNode"
+  annotation = var.annotation
+  content = {
+    funcTemplateType = each.value.template_type
+    funcType         = each.value.function
+    isCopy           = each.value.copy_device ? "yes" : "no"
+    managed          = each.value.managed ? "yes" : "no"
+    name             = each.value.node_name
+    routingMode      = var.redirect ? "Redirect" : "unspecified"
+    sequenceNumber   = tostring(each.value.index)
+    shareEncap       = var.share_encapsulation ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vnsAbsFuncConn_Provider_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if !v.copy_device } : {}
+  dn         = "${aci_rest_managed.vnsAbsNode_multi[each.key].dn}/AbsFConn-provider"
+  class_name = "vnsAbsFuncConn"
+  annotation = var.annotation
+  content = {
+    attNotify = "no"
+    name      = "provider"
+  }
+}
+
+resource "aci_rest_managed" "vnsAbsFuncConn_Consumer_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if !v.copy_device } : {}
+  dn         = "${aci_rest_managed.vnsAbsNode_multi[each.key].dn}/AbsFConn-consumer"
+  class_name = "vnsAbsFuncConn"
+  annotation = var.annotation
+  content = {
+    attNotify = "no"
+    name      = "consumer"
+  }
+}
+
+resource "aci_rest_managed" "vnsAbsFuncConn_Copy_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.copy_device } : {}
+  dn         = "${aci_rest_managed.vnsAbsNode_multi[each.key].dn}/AbsFConn-copy"
+  class_name = "vnsAbsFuncConn"
+  annotation = var.annotation
+  content = {
+    attNotify = "no"
+    name      = "copy"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsNodeToLDev_multi" {
+  for_each   = local.multi_device_mode ? local.devices_map : {}
+  dn         = "${aci_rest_managed.vnsAbsNode_multi[each.key].dn}/rsNodeToLDev"
+  class_name = "vnsRsNodeToLDev"
+  annotation = var.annotation != null ? "" : null
+  content = {
+    tDn = each.value.tenant == var.tenant ? "uni/tn-${var.tenant}/lDevVip-${each.value.name}" : "uni/tn-${var.tenant}/lDevIf-[uni/tn-${each.value.tenant}/lDevVip-${each.value.name}]"
+  }
+}
+
+resource "aci_rest_managed" "vnsAbsConnection_multi" {
+  for_each   = local.multi_device_mode ? local.connections_map : {}
+  dn         = "${aci_rest_managed.vnsAbsGraph.dn}/AbsConnection-${each.value.name}"
+  class_name = "vnsAbsConnection"
+  annotation = var.annotation
+  content = {
+    adjType       = each.value.adjacency_type
+    connDir       = "provider"
+    connType      = "external"
+    directConnect = each.value.direct_connect ? "yes" : "no"
+    name          = each.value.name
+    unicastRoute  = each.value.unicast_route ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsAbsCopyConnection_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.connections_map : k => v if v.copy_node != null } : {}
+  dn         = "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsCopyConnection-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_copy_node}/AbsFConn-copy]"
+  class_name = "vnsRsAbsCopyConnection"
+  annotation = var.annotation
+  content = {
+    tDn = "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_copy_node}/AbsFConn-copy"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsAbsConnectionConns_Consumer_multi" {
+  for_each   = local.multi_device_mode ? local.connections_map : {}
+  dn         = each.value.consumer_node == "EPG-Consumer" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-consumer]"
+  class_name = "vnsRsAbsConnectionConns"
+  annotation = var.annotation
+  content = {
+    tDn = each.value.consumer_node == "EPG-Consumer" ? aci_rest_managed.vnsAbsTermConn_T1.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-consumer"
+  }
+  depends_on = [
+    aci_rest_managed.vnsRsAbsCopyConnection_multi
+  ]
+}
+
+resource "aci_rest_managed" "vnsRsAbsConnectionConns_Provider_multi" {
+  for_each   = local.multi_device_mode ? local.connections_map : {}
+  dn         = each.value.provider_node == "EPG-Provider" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T2.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-provider]"
+  class_name = "vnsRsAbsConnectionConns"
+  annotation = var.annotation
+  content = {
+    tDn = each.value.provider_node == "EPG-Provider" ? aci_rest_managed.vnsAbsTermConn_T2.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-provider"
+  }
+  depends_on = [
+    aci_rest_managed.vnsRsAbsCopyConnection_multi
   ]
 }

--- a/modules/terraform-aci-service-graph-template/main.tf
+++ b/modules/terraform-aci-service-graph-template/main.tf
@@ -2,31 +2,44 @@ locals {
   multi_device_mode = length(var.devices) > 0
 
   devices_map = {
-    for idx, device in var.devices : device.name => {
+    for idx, device in var.devices : coalesce(device.node_name, device.name) => {
       index         = idx
       name          = device.name
       tenant        = coalesce(device.tenant, var.tenant)
       node_name     = coalesce(device.node_name, device.name)
-      template_type = coalesce(device.template_type, var.template_type)
-      function      = coalesce(device.function, "GoTo")
-      copy_device   = coalesce(device.copy_device, false)
-      managed       = coalesce(device.managed, false)
+      template_type = device.template_type
+      function      = device.function
+      copy_device   = device.copy_device
+      managed       = device.managed
     }
   }
 
   connections_map = {
     for idx, conn in var.connections : "C${idx + 1}" => {
-      index                  = idx
-      name                   = "C${idx + 1}"
-      consumer_node          = conn.consumer_node
-      provider_node          = conn.provider_node
-      copy_node              = conn.copy_node
-      adjacency_type         = coalesce(conn.adjacency_type, "L2")
-      unicast_route          = coalesce(conn.unicast_route, true)
-      direct_connect         = coalesce(conn.direct_connect, false)
-      resolved_consumer_node = conn.consumer_node == "EPG-Consumer" ? "EPG-Consumer" : try(local.devices_map[conn.consumer_node].node_name, conn.consumer_node)
-      resolved_provider_node = conn.provider_node == "EPG-Provider" ? "EPG-Provider" : try(local.devices_map[conn.provider_node].node_name, conn.provider_node)
-      resolved_copy_node     = conn.copy_node != null ? try(local.devices_map[conn.copy_node].node_name, conn.copy_node) : null
+      index          = idx
+      name           = "C${idx + 1}"
+      consumer_node  = conn.consumer_node
+      provider_node  = conn.provider_node
+      copy_node      = conn.copy_node
+      adjacency_type = coalesce(conn.adjacency_type, "L2")
+      unicast_route  = coalesce(conn.unicast_route, true)
+      direct_connect = coalesce(conn.direct_connect, false)
+      # Resolve node references: first try devices_map (keyed by node_name), then search by device name
+      resolved_consumer_node = conn.consumer_node == "EPG-Consumer" ? "EPG-Consumer" : try(
+        local.devices_map[conn.consumer_node].node_name,
+        [for d in var.devices : coalesce(d.node_name, d.name) if d.name == conn.consumer_node][0],
+        conn.consumer_node
+      )
+      resolved_provider_node = conn.provider_node == "EPG-Provider" ? "EPG-Provider" : try(
+        local.devices_map[conn.provider_node].node_name,
+        [for d in var.devices : coalesce(d.node_name, d.name) if d.name == conn.provider_node][0],
+        conn.provider_node
+      )
+      resolved_copy_node = conn.copy_node != null ? try(
+        local.devices_map[conn.copy_node].node_name,
+        [for d in var.devices : coalesce(d.node_name, d.name) if d.name == conn.copy_node][0],
+        conn.copy_node
+      ) : null
     }
   }
 }

--- a/modules/terraform-aci-service-graph-template/variables.tf
+++ b/modules/terraform-aci-service-graph-template/variables.tf
@@ -75,8 +75,9 @@ variable "share_encapsulation" {
 }
 
 variable "device_name" {
-  description = "L4L7 device name."
+  description = "L4L7 device name. Required for legacy single-device mode, not used when `devices` is specified."
   type        = string
+  default     = ""
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.device_name))
@@ -150,4 +151,66 @@ variable "provider_direct_connect" {
   description = "Direct connect on provider connection."
   type        = bool
   default     = false
+}
+
+variable "devices" {
+  description = "List of devices for multi-device service graph. When specified, legacy device variables are ignored."
+  type = list(object({
+    name          = string
+    tenant        = optional(string)
+    node_name     = optional(string)
+    template_type = optional(string)
+    function      = optional(string)
+    copy_device   = optional(bool)
+    managed       = optional(bool)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for device in var.devices : can(regex("^[a-zA-Z0-9_.:-]{1,64}$", device.name))
+    ])
+    error_message = "Device name must match: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. 1-64 characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for device in var.devices : device.node_name == null || can(regex("^[a-zA-Z0-9_.:-]{1,64}$", device.node_name))
+    ])
+    error_message = "Device node_name must match: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. 1-64 characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for device in var.devices : device.template_type == null || contains(["FW_TRANS", "FW_ROUTED", "ADC_ONE_ARM", "ADC_TWO_ARM", "OTHER", "CLOUD_NATIVE_LB", "CLOUD_VENDOR_LB", "CLOUD_NATIVE_FW", "CLOUD_VENDOR_FW"], device.template_type)
+    ])
+    error_message = "Device template_type must be one of: `FW_TRANS`, `FW_ROUTED`, `ADC_ONE_ARM`, `ADC_TWO_ARM`, `OTHER`, `CLOUD_NATIVE_LB`, `CLOUD_VENDOR_LB`, `CLOUD_NATIVE_FW`, `CLOUD_VENDOR_FW`."
+  }
+
+  validation {
+    condition = alltrue([
+      for device in var.devices : device.function == null || contains(["None", "GoTo", "GoThrough", "L2", "L1"], device.function)
+    ])
+    error_message = "Device function must be one of: `None`, `GoTo`, `GoThrough`, `L2`, `L1`."
+  }
+}
+
+variable "connections" {
+  description = "List of connections for multi-device service graph."
+  type = list(object({
+    consumer_node  = string
+    provider_node  = string
+    copy_node      = optional(string)
+    adjacency_type = optional(string)
+    unicast_route  = optional(bool)
+    direct_connect = optional(bool)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for conn in var.connections : conn.adjacency_type == null || contains(["L2", "L3"], conn.adjacency_type)
+    ])
+    error_message = "Connection adjacency_type must be one of: `L2`, `L3`."
+  }
 }


### PR DESCRIPTION
Add support for SG Templates multi-nodes ensuring backwards compatibility.

Data model tested:

``` yaml
apic:
  tenants:
    - name: SGT-LegacyApproach
      services:
        service_graph_templates:
          - name: PBR_SG_template
            device:
              name: FW
              node_name: NodeFW
        l4l7_devices:
          - name: FW

    - name: SGT-NewApproach
      services:
        service_graph_templates:
          - name: PBR_SG_OtherTenant
            devices:
              - name: FW
                node_name: FW_CLUSTER
                tenant: SGT-LegacyApproach
            connections:
              - consumer_node: EPG-Consumer
                provider_node: FW
              - consumer_node: FW
                provider_node: EPG-Provider
          - name: PBR_SG_Minimal
            devices:
              - name: Node-1
              - name: Node-2
              - name: CopyDevice-1
            connections:
              - consumer_node: EPG-Consumer
                provider_node: Node-1
                copy_node: CopyDevice-1
              - consumer_node: Node-1
                provider_node: Node-2
                copy_node: CopyDevice-1
              - consumer_node: Node-2
                provider_node: EPG-Provider
          - name: PBR_SG_Full
            devices:
              - name: Node-1
                node_name: N1
              - name: CopyDevice-1
                node_name: C1
              - name: CopyDevice-2
                node_name: C2
              - name: Node-2
                node_name: N2
            connections:
              - consumer_node: EPG-Consumer
                provider_node: Node-1
                copy_node: CopyDevice-1
              - consumer_node: Node-1
                provider_node: Node-2
                copy_node: CopyDevice-2
                adjacency_type: L2
                unicast_route: false
              - consumer_node: Node-2
                provider_node: EPG-Provider
                copy_node: CopyDevice-1
                direct_connect: true
          - name: PBR_SG_Device_Reuse
            devices:
              - name: Node-1
                node_name: N1
              - name: Node-1
                node_name: N2
            connections:
              - consumer_node: EPG-Consumer
                provider_node: N1
              - consumer_node: N1
                provider_node: N2
              - consumer_node: N2
                provider_node: EPG-Provider
        l4l7_devices:
          - name: Node-1
          - name: Node-2
          - name: CopyDevice-1
            copy_device: true
            function: None
            service_type: COPY
          - name: CopyDevice-2
            copy_device: true
            function: None
            service_type: COPY
        imported_l4l7_devices:
          - name: FW
            tenant: SGT-LegacyApproach

```