### PR TITLE
fix: use composite key in DHCP relay policy loop to support duplicate provider IPs

### DIFF
--- a/modules/terraform-aci-dhcp-relay-policy/main.tf
+++ b/modules/terraform-aci-dhcp-relay-policy/main.tf
@@ -9,7 +9,7 @@ resource "aci_rest_managed" "dhcpRelayP" {
 }
 
 resource "aci_rest_managed" "dhcpRsProv" {
-  for_each   = { for prov in var.providers_ : prov.ip => prov }
+  for_each   = { for prov in var.providers_ : "${prov.ip}/${prov.type == "epg" ? "${lookup(prov, "tenant", var.tenant)}-${prov.application_profile}-${prov.endpoint_group}" : "${lookup(prov, "tenant", var.tenant)}-${prov.l3out}-${prov.external_endpoint_group}"}" => prov }
   dn         = each.value.type == "epg" ? "${aci_rest_managed.dhcpRelayP.dn}/rsprov-[uni/tn-${lookup(each.value, "tenant", var.tenant)}/ap-${each.value.application_profile}/epg-${each.value.endpoint_group}]" : "${aci_rest_managed.dhcpRelayP.dn}/rsprov-[uni/tn-${lookup(each.value, "tenant", var.tenant)}/out-${each.value.l3out}/instP-${each.value.external_endpoint_group}]"
   class_name = "dhcpRsProv"
   content = {


### PR DESCRIPTION
The `for_each` key used as part of the DHCP relay policy loop only used `prov.ip`, causing a "Duplicate object key" error when multiple providers share the same IP but target different EPGs. This PR modifies the key to be a composite key constructed from various attributes of each DHCP relay policy, which substantially reduces the chance of collisions.