### PR TITLE
Fix ESG IP Ext Subnet Sel support for IPv6

### DIFF
--- a/modules/terraform-aci-endpoint-security-group/variables.tf
+++ b/modules/terraform-aci-endpoint-security-group/variables.tf
@@ -276,13 +276,6 @@ variable "ip_external_subnet_selectors" {
 
   validation {
     condition = alltrue([
-      for ess in var.ip_external_subnet_selectors : can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}\\/([0-9]){1,2}$", ess.ip))
-    ])
-    error_message = "`ip`: Valid ip format example: 192.168.1.0/24."
-  }
-
-  validation {
-    condition = alltrue([
       for ess in var.ip_external_subnet_selectors : ess.description == null || can(regex("^[a-zA-Z0-9\\\\!#$%()*,-./:;@ _{|}~?&+]{0,128}$", ess.description))
     ])
     error_message = "`description`: Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `\\`, `!`, `#`, `$`, `%`, `(`, `)`, `*`, `,`, `-`, `.`, `/`, `:`, `;`, `@`, ` `, `_`, `{`, `|`, }`, `~`, `?`, `&`, `+`. Maximum characters: 128."


### PR DESCRIPTION
Potential solution for this [Issue 375](https://github.com/netascode/terraform-aci-nac-aci/issues/375)

In Terraform NAC, we do not put restriction to vars when IPv4 and IPv6 are supported. `nac-validate` tool takes care of these syntactic checks, instead.

Validation:
```hcl
> terraform plan 2>&1 | grep -A 10 fvExternalSubnetSelector
  # module.aci.module.aci_endpoint_security_group["i375terraform/OCP-L3OUT-ANP/OCP-FLOATING-L3OUT-ESG"].aci_rest_managed.fvExternalSubnetSelector["2001:420:207f:f858::0/64"] will be created
  + resource "aci_rest_managed" "fvExternalSubnetSelector" {
      + annotation  = "orchestrator:terraform"
      + class_name  = "fvExternalSubnetSelector"
      + content     = {
          + "descr"  = "OCP-FLOATING-L3OUT External Subnet Selector"
          + "shared" = "no"
        }
      + dn          = "uni/tn-i375terraform/ap-OCP-L3OUT-ANP/esg-OCP-FLOATING-L3OUT-ESG/extsubselector-[2001:420:207f:f858::0/64]"
      + escape_html = true
      + id          = (known after apply)
    }
```
