### PR TITLE
Add explicit-failover mode to port channel policy

### DIFF
--- a/modules/terraform-aci-port-channel-policy/README.md
+++ b/modules/terraform-aci-port-channel-policy/README.md
@@ -44,7 +44,7 @@ module "aci_port_channel_policy" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Port channel policy name. | `string` | n/a | yes |
-| <a name="input_mode"></a> [mode](#input\_mode) | Mode. Choices: `off`, `active`, `passive`, `mac-pin`, `mac-pin-nicload`. | `string` | n/a | yes |
+| <a name="input_mode"></a> [mode](#input\_mode) | Mode. Choices: `off`, `active`, `passive`, `mac-pin`, `mac-pin-nicload`, `explicit-failover`. | `string` | n/a | yes |
 | <a name="input_min_links"></a> [min\_links](#input\_min\_links) | Minimum links. Minimum value: 1. Maximum value: 16. | `number` | `1` | no |
 | <a name="input_max_links"></a> [max\_links](#input\_max\_links) | Maximum links. Minimum value: 1. Maximum value: 16. | `number` | `16` | no |
 | <a name="input_suspend_individual"></a> [suspend\_individual](#input\_suspend\_individual) | Suspend individual. | `bool` | `true` | no |

--- a/modules/terraform-aci-port-channel-policy/variables.tf
+++ b/modules/terraform-aci-port-channel-policy/variables.tf
@@ -9,12 +9,12 @@ variable "name" {
 }
 
 variable "mode" {
-  description = "Mode. Choices: `off`, `active`, `passive`, `mac-pin`, `mac-pin-nicload`."
+  description = "Mode. Choices: `off`, `active`, `passive`, `mac-pin`, `mac-pin-nicload`, `explicit-failover`."
   type        = string
 
   validation {
-    condition     = contains(["off", "active", "passive", "mac-pin", "mac-pin-nicload"], var.mode)
-    error_message = "Allowed values are `off`, `active`, `passive`, `mac-pin` or `mac-pin-nicload`."
+    condition     = contains(["off", "active", "passive", "mac-pin", "mac-pin-nicload", "explicit-failover"], var.mode)
+    error_message = "Allowed values are `off`, `active`, `passive`, `mac-pin`, `mac-pin-nicload` or `explicit-failover`."
   }
 }
 


### PR DESCRIPTION
Add `explicit-failover` as a valid `mode` for the `terraform-aci-port-channel-policy` module. Updates variable validation, description, and README.

### Verification

Validated using the following data model applied against a live ACI fabric:

```yaml
apic:
  access_policies:
    interface_policies:
      port_channel_policies:
        - name: 'EXPLICIT-FAILOVER-TEST'
          mode: explicit-failover
```

- `terraform apply` completed successfully against a live APIC fabric, confirming the `lacpLagPol` managed object was created with `mode: explicit-failover`
- `terraform validate` passes with the patched module and a dev override of the ACI provider that also accepts `explicit-failover`
- Previously, the module's variable validation rejected `explicit-failover` with: `Allowed values are "off", "active", "passive", "mac-pin" or "mac-pin-nicload".`

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-opus-4-6
- **AI Contribution**: ~90%
- **AI Reason**: add explicit-failover mode to port channel policy module
- **Human Oversight**: Code reviewed and approved by @ChristopherJHart