### PR TITLE
Add Device Sel Pol multinode support

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -4137,6 +4137,8 @@ locals {
         tenant                 = tenant.name
         contract               = "${dsp.contract}${local.defaults.apic.tenants.contracts.name_suffix}"
         service_graph_template = "${dsp.service_graph_template}${local.defaults.apic.tenants.services.service_graph_templates.name_suffix}"
+        # Determine if legacy mode: device_name, node_name, consumer, provider or copy_service defined at root level
+        legacy_mode = try(dsp.device_name, null) != null || try(dsp.node_name, null) != null || try(dsp.consumer, null) != null || try(dsp.provider, null) != null || try(dsp.copy_service, null) != null
         sgt_device_tenant = length(try(tenant.services.service_graph_templates, [])) != 0 ? [for sg_template in try(tenant.services.service_graph_templates, []) : (
           length(try(sg_template.devices, [])) > 0 ?
           [for dev in sg_template.devices : try(dev.tenant, tenant.name) if sg_template.name == dsp.service_graph_template][0] :
@@ -4188,6 +4190,76 @@ locals {
         copy_custom_qos_policy                                  = try("${dsp.copy_service.custom_qos_policy}${local.defaults.apic.tenants.policies.custom_qos.name_suffix}", "")
         copy_service_epg_policy                                 = try("${dsp.copy_service.service_epg_policy}${local.defaults.apic.tenants.services.service_epg_policies.name_suffix}", "")
         copy_service_epg_policy_tenant                          = tenant.name
+        # Multi-device mode: build devices list with name suffixes applied
+        # Device tenant is determined by looking up the device name in imported_l4l7_devices
+        # (per schema, device_selection_policies.devices does not have a tenant field;
+        # the tenant info comes from services.imported_l4l7_devices.tenant)
+        devices = try(dsp.device_name, null) != null || try(dsp.node_name, null) != null || try(dsp.consumer, null) != null || try(dsp.provider, null) != null || try(dsp.copy_service, null) != null ? [] : [
+          for device in try(dsp.devices, []) : {
+            name      = "${device.name}${local.defaults.apic.tenants.services.l4l7_devices.name_suffix}"
+            tenant    = length([for imp in try(tenant.services.imported_l4l7_devices, []) : imp.tenant if imp.name == device.name]) > 0 ? [for imp in try(tenant.services.imported_l4l7_devices, []) : imp.tenant if imp.name == device.name][0] : null
+            node_name = try(device.node_name, null)
+            consumer = try(device.consumer, null) != null ? {
+              l3_destination    = try(device.consumer.l3_destination, local.defaults.apic.tenants.services.device_selection_policies.devices.consumer.l3_destination)
+              permit_logging    = try(device.consumer.permit_logging, local.defaults.apic.tenants.services.device_selection_policies.devices.consumer.permit_logging)
+              logical_interface = "${device.consumer.logical_interface}${local.defaults.apic.tenants.services.l4l7_devices.logical_interfaces.name_suffix}"
+              redirect_policy = try(device.consumer.redirect_policy, null) != null ? {
+                name   = "${device.consumer.redirect_policy.name}${local.defaults.apic.tenants.services.redirect_policies.name_suffix}"
+                tenant = try(device.consumer.redirect_policy.tenant, null)
+              } : null
+              bridge_domain = try(device.consumer.bridge_domain, null) != null ? {
+                name   = "${device.consumer.bridge_domain.name}${local.defaults.apic.tenants.bridge_domains.name_suffix}"
+                tenant = try(device.consumer.bridge_domain.tenant, null)
+              } : null
+              external_endpoint_group = try(device.consumer.external_endpoint_group, null) != null ? {
+                tenant = try(device.consumer.external_endpoint_group.tenant, null)
+                l3out  = "${device.consumer.external_endpoint_group.l3out}${local.defaults.apic.tenants.l3outs.name_suffix}"
+                name   = "${device.consumer.external_endpoint_group.name}${local.defaults.apic.tenants.l3outs.external_endpoint_groups.name_suffix}"
+                redistribute = try(device.consumer.external_endpoint_group.redistribute, null) != null ? {
+                  bgp       = try(device.consumer.external_endpoint_group.redistribute.bgp, local.defaults.apic.tenants.services.device_selection_policies.devices.consumer.external_endpoint_group.redistribute.bgp)
+                  ospf      = try(device.consumer.external_endpoint_group.redistribute.ospf, local.defaults.apic.tenants.services.device_selection_policies.devices.consumer.external_endpoint_group.redistribute.ospf)
+                  connected = try(device.consumer.external_endpoint_group.redistribute.connected, local.defaults.apic.tenants.services.device_selection_policies.devices.consumer.external_endpoint_group.redistribute.connected)
+                  static    = try(device.consumer.external_endpoint_group.redistribute.static, local.defaults.apic.tenants.services.device_selection_policies.devices.consumer.external_endpoint_group.redistribute.static)
+                } : null
+              } : null
+              service_epg_policy = try("${device.consumer.service_epg_policy}${local.defaults.apic.tenants.services.service_epg_policies.name_suffix}", null)
+              custom_qos_policy  = try("${device.consumer.custom_qos_policy}${local.defaults.apic.tenants.policies.custom_qos.name_suffix}", null)
+            } : null
+            provider = try(device.provider, null) != null ? {
+              l3_destination    = try(device.provider.l3_destination, local.defaults.apic.tenants.services.device_selection_policies.devices.provider.l3_destination)
+              permit_logging    = try(device.provider.permit_logging, local.defaults.apic.tenants.services.device_selection_policies.devices.provider.permit_logging)
+              logical_interface = "${device.provider.logical_interface}${local.defaults.apic.tenants.services.l4l7_devices.logical_interfaces.name_suffix}"
+              redirect_policy = try(device.provider.redirect_policy, null) != null ? {
+                name   = "${device.provider.redirect_policy.name}${local.defaults.apic.tenants.services.redirect_policies.name_suffix}"
+                tenant = try(device.provider.redirect_policy.tenant, null)
+              } : null
+              bridge_domain = try(device.provider.bridge_domain, null) != null ? {
+                name   = "${device.provider.bridge_domain.name}${local.defaults.apic.tenants.bridge_domains.name_suffix}"
+                tenant = try(device.provider.bridge_domain.tenant, null)
+              } : null
+              external_endpoint_group = try(device.provider.external_endpoint_group, null) != null ? {
+                tenant = try(device.provider.external_endpoint_group.tenant, null)
+                l3out  = "${device.provider.external_endpoint_group.l3out}${local.defaults.apic.tenants.l3outs.name_suffix}"
+                name   = "${device.provider.external_endpoint_group.name}${local.defaults.apic.tenants.l3outs.external_endpoint_groups.name_suffix}"
+                redistribute = try(device.provider.external_endpoint_group.redistribute, null) != null ? {
+                  bgp       = try(device.provider.external_endpoint_group.redistribute.bgp, local.defaults.apic.tenants.services.device_selection_policies.devices.provider.external_endpoint_group.redistribute.bgp)
+                  ospf      = try(device.provider.external_endpoint_group.redistribute.ospf, local.defaults.apic.tenants.services.device_selection_policies.devices.provider.external_endpoint_group.redistribute.ospf)
+                  connected = try(device.provider.external_endpoint_group.redistribute.connected, local.defaults.apic.tenants.services.device_selection_policies.devices.provider.external_endpoint_group.redistribute.connected)
+                  static    = try(device.provider.external_endpoint_group.redistribute.static, local.defaults.apic.tenants.services.device_selection_policies.devices.provider.external_endpoint_group.redistribute.static)
+                } : null
+              } : null
+              service_epg_policy = try("${device.provider.service_epg_policy}${local.defaults.apic.tenants.services.service_epg_policies.name_suffix}", null)
+              custom_qos_policy  = try("${device.provider.custom_qos_policy}${local.defaults.apic.tenants.policies.custom_qos.name_suffix}", null)
+            } : null
+            copy_service = try(device.copy_service, null) != null ? {
+              l3_destination     = try(device.copy_service.l3_destination, local.defaults.apic.tenants.services.device_selection_policies.devices.copy_service.l3_destination)
+              permit_logging     = try(device.copy_service.permit_logging, local.defaults.apic.tenants.services.device_selection_policies.devices.copy_service.permit_logging)
+              logical_interface  = "${device.copy_service.logical_interface}${local.defaults.apic.tenants.services.l4l7_devices.logical_interfaces.name_suffix}"
+              service_epg_policy = try("${device.copy_service.service_epg_policy}${local.defaults.apic.tenants.services.service_epg_policies.name_suffix}", null)
+              custom_qos_policy  = try("${device.copy_service.custom_qos_policy}${local.defaults.apic.tenants.policies.custom_qos.name_suffix}", null)
+            } : null
+          }
+        ]
       }
     ]
   ])
@@ -4243,6 +4315,7 @@ module "aci_device_selection_policy" {
   copy_custom_qos_policy                                  = each.value.copy_custom_qos_policy
   copy_service_epg_policy                                 = each.value.copy_service_epg_policy
   copy_service_epg_policy_tenant                          = each.value.copy_service_epg_policy_tenant
+  devices                                                 = each.value.devices
 
   depends_on = [
     module.aci_tenant,

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1874,3 +1874,25 @@ defaults:
           copy_service:
             l3_destination: true
             permit_logging: false
+          devices:
+            consumer:
+              l3_destination: true
+              permit_logging: false
+              external_endpoint_group:
+                redistribute:
+                  bgp: false
+                  ospf: false
+                  connected: false
+                  static: false
+            provider:
+              l3_destination: true
+              permit_logging: false
+              external_endpoint_group:
+                redistribute:
+                  bgp: false
+                  ospf: false
+                  connected: false
+                  static: false
+            copy_service:
+              l3_destination: true
+              permit_logging: false

--- a/modules/terraform-aci-device-selection-policy/README.md
+++ b/modules/terraform-aci-device-selection-policy/README.md
@@ -9,6 +9,7 @@ Location in GUI:
 ## Examples
 
 ```hcl
+# Legacy single-device mode example
 module "aci_device_selection_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-device-selection-policy"
   version = ">= 0.8.0"
@@ -36,6 +37,65 @@ module "aci_device_selection_policy" {
   provider_service_epg_policy                             = "SEPGP1"
   provider_custom_qos_policy                              = "QOSP1"
 }
+
+# Multi-device mode example
+module "aci_device_selection_policy_multi" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-device-selection-policy"
+  version = "> 1.2.0"
+
+  tenant                 = "ABC"
+  contract               = "CON2"
+  service_graph_template = "SGT2"
+
+  devices = [
+    {
+      name      = "FW1"
+      tenant    = "COMMON"
+      node_name = "FW1_NODE"
+      consumer = {
+        l3_destination    = true
+        permit_logging    = false
+        logical_interface = "CONSUMER_INT"
+        redirect_policy = {
+          name   = "REDIR_CONSUMER"
+          tenant = "ABC"
+        }
+      }
+      provider = {
+        l3_destination    = true
+        permit_logging    = false
+        logical_interface = "PROVIDER_INT"
+        redirect_policy = {
+          name   = "REDIR_PROVIDER"
+          tenant = "ABC"
+        }
+      }
+    },
+    {
+      name      = "LB1"
+      node_name = "LB1_NODE"
+      consumer = {
+        logical_interface = "LB_CONSUMER_INT"
+        bridge_domain = {
+          name   = "BD_CONSUMER"
+          tenant = "ABC"
+        }
+      }
+      provider = {
+        logical_interface = "LB_PROVIDER_INT"
+        external_endpoint_group = {
+          tenant = "ABC"
+          l3out  = "L3OUT1"
+          name   = "EXTEPG1"
+          redistribute = {
+            bgp       = true
+            connected = true
+          }
+        }
+      }
+    }
+  ]
+}
 ```
 
 ## Requirements
@@ -59,7 +119,7 @@ module "aci_device_selection_policy" {
 | <a name="input_contract"></a> [contract](#input\_contract) | Contract name. | `string` | n/a | yes |
 | <a name="input_service_graph_template"></a> [service\_graph\_template](#input\_service\_graph\_template) | Service graph template name. | `string` | n/a | yes |
 | <a name="input_sgt_device_tenant"></a> [sgt\_device\_tenant](#input\_sgt\_device\_tenant) | Device tenant name. | `string` | `""` | no |
-| <a name="input_sgt_device_name"></a> [sgt\_device\_name](#input\_sgt\_device\_name) | Device name. | `string` | n/a | yes |
+| <a name="input_sgt_device_name"></a> [sgt\_device\_name](#input\_sgt\_device\_name) | Device name. Required for legacy single-device mode, not used when `devices` is specified. | `string` | `""` | no |
 | <a name="input_node_name"></a> [node\_name](#input\_node\_name) | Function node name. | `string` | `"N1"` | no |
 | <a name="input_consumer_l3_destination"></a> [consumer\_l3\_destination](#input\_consumer\_l3\_destination) | Consumer L3 destination. | `bool` | `false` | no |
 | <a name="input_consumer_permit_logging"></a> [consumer\_permit\_logging](#input\_consumer\_permit\_logging) | Consumer permit logging. | `bool` | `false` | no |
@@ -101,35 +161,56 @@ module "aci_device_selection_policy" {
 | <a name="input_copy_custom_qos_policy"></a> [copy\_custom\_qos\_policy](#input\_copy\_custom\_qos\_policy) | Copy custom QoS policy name. | `string` | `""` | no |
 | <a name="input_copy_service_epg_policy"></a> [copy\_service\_epg\_policy](#input\_copy\_service\_epg\_policy) | Copy service EPG policy name. | `string` | `""` | no |
 | <a name="input_copy_service_epg_policy_tenant"></a> [copy\_service\_epg\_policy\_tenant](#input\_copy\_service\_epg\_policy\_tenant) | Copy service EPG policy tenant name. | `string` | `""` | no |
+| <a name="input_devices"></a> [devices](#input\_devices) | List of devices for multi-device device selection policy. When specified, legacy single-device variables (device\_name, node\_name, consumer, provider, copy\_service at root level) are ignored. | <pre>list(object({<br/>    name      = string<br/>    tenant    = optional(string)<br/>    node_name = optional(string)<br/>    consumer = optional(object({<br/>      l3_destination    = optional(bool)<br/>      permit_logging    = optional(bool)<br/>      logical_interface = string<br/>      redirect_policy = optional(object({<br/>        name   = string<br/>        tenant = optional(string)<br/>      }))<br/>      bridge_domain = optional(object({<br/>        name   = string<br/>        tenant = optional(string)<br/>      }))<br/>      external_endpoint_group = optional(object({<br/>        tenant = optional(string)<br/>        l3out  = string<br/>        name   = string<br/>        redistribute = optional(object({<br/>          bgp       = optional(bool)<br/>          ospf      = optional(bool)<br/>          connected = optional(bool)<br/>          static    = optional(bool)<br/>        }))<br/>      }))<br/>      service_epg_policy = optional(string)<br/>      custom_qos_policy  = optional(string)<br/>    }))<br/>    provider = optional(object({<br/>      l3_destination    = optional(bool)<br/>      permit_logging    = optional(bool)<br/>      logical_interface = string<br/>      redirect_policy = optional(object({<br/>        name   = string<br/>        tenant = optional(string)<br/>      }))<br/>      bridge_domain = optional(object({<br/>        name   = string<br/>        tenant = optional(string)<br/>      }))<br/>      external_endpoint_group = optional(object({<br/>        tenant = optional(string)<br/>        l3out  = string<br/>        name   = string<br/>        redistribute = optional(object({<br/>          bgp       = optional(bool)<br/>          ospf      = optional(bool)<br/>          connected = optional(bool)<br/>          static    = optional(bool)<br/>        }))<br/>      }))<br/>      service_epg_policy = optional(string)<br/>      custom_qos_policy  = optional(string)<br/>    }))<br/>    copy_service = optional(object({<br/>      l3_destination     = optional(bool)<br/>      permit_logging     = optional(bool)<br/>      logical_interface  = string<br/>      service_epg_policy = optional(string)<br/>      custom_qos_policy  = optional(string)<br/>    }))<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_dn"></a> [dn](#output\_dn) | Distinguished name of `vnsLDevCtx` object. |
+| <a name="output_dn"></a> [dn](#output\_dn) | Distinguished name of `vnsLDevCtx` object(s). Returns a list of DNs. |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aci_rest_managed.vnsLDevCtx](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsLDevCtx_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsLIfCtx_consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsLIfCtx_consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsLIfCtx_copy](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsLIfCtx_copy_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsLIfCtx_provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsLIfCtx_provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLDevCtxToLDev](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLDevCtxToLDev_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToBD_consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToBD_consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToBD_provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToBD_provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToCustQosPol_consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToCustQosPol_consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToCustQosPol_copy](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToCustQosPol_copy_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToCustQosPol_provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToCustQosPol_provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToInstP_consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToInstP_consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToInstP_provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToInstP_provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToLIf_consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToLIf_consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToLIf_copy](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToLIf_copy_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToLIf_provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToLIf_provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToSvcEPgPol_consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToSvcEPgPol_consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToSvcEPgPol_copy](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToSvcEPgPol_copy_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToSvcEPgPol_provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToSvcEPgPol_provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToSvcRedirectPol_consumer](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToSvcRedirectPol_consumer_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.vnsRsLIfCtxToSvcRedirectPol_provider](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.vnsRsLIfCtxToSvcRedirectPol_provider_multi](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-device-selection-policy/examples/complete/README.md
+++ b/modules/terraform-aci-device-selection-policy/examples/complete/README.md
@@ -12,6 +12,7 @@ $ terraform apply
 Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
 
 ```hcl
+# Legacy single-device mode example
 module "aci_device_selection_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-device-selection-policy"
   version = ">= 0.8.0"
@@ -38,6 +39,65 @@ module "aci_device_selection_policy" {
   provider_external_endpoint_group_redistribute_static    = true
   provider_service_epg_policy                             = "SEPGP1"
   provider_custom_qos_policy                              = "QOSP1"
+}
+
+# Multi-device mode example
+module "aci_device_selection_policy_multi" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-device-selection-policy"
+  version = "> 1.2.0"
+
+  tenant                 = "ABC"
+  contract               = "CON2"
+  service_graph_template = "SGT2"
+
+  devices = [
+    {
+      name      = "FW1"
+      tenant    = "COMMON"
+      node_name = "FW1_NODE"
+      consumer = {
+        l3_destination    = true
+        permit_logging    = false
+        logical_interface = "CONSUMER_INT"
+        redirect_policy = {
+          name   = "REDIR_CONSUMER"
+          tenant = "ABC"
+        }
+      }
+      provider = {
+        l3_destination    = true
+        permit_logging    = false
+        logical_interface = "PROVIDER_INT"
+        redirect_policy = {
+          name   = "REDIR_PROVIDER"
+          tenant = "ABC"
+        }
+      }
+    },
+    {
+      name      = "LB1"
+      node_name = "LB1_NODE"
+      consumer = {
+        logical_interface = "LB_CONSUMER_INT"
+        bridge_domain = {
+          name   = "BD_CONSUMER"
+          tenant = "ABC"
+        }
+      }
+      provider = {
+        logical_interface = "LB_PROVIDER_INT"
+        external_endpoint_group = {
+          tenant = "ABC"
+          l3out  = "L3OUT1"
+          name   = "EXTEPG1"
+          redistribute = {
+            bgp       = true
+            connected = true
+          }
+        }
+      }
+    }
+  ]
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-device-selection-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-device-selection-policy/examples/complete/main.tf
@@ -1,3 +1,4 @@
+# Legacy single-device mode example
 module "aci_device_selection_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-device-selection-policy"
   version = ">= 0.8.0"
@@ -24,4 +25,63 @@ module "aci_device_selection_policy" {
   provider_external_endpoint_group_redistribute_static    = true
   provider_service_epg_policy                             = "SEPGP1"
   provider_custom_qos_policy                              = "QOSP1"
+}
+
+# Multi-device mode example
+module "aci_device_selection_policy_multi" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-device-selection-policy"
+  version = "> 1.2.0"
+
+  tenant                 = "ABC"
+  contract               = "CON2"
+  service_graph_template = "SGT2"
+
+  devices = [
+    {
+      name      = "FW1"
+      tenant    = "COMMON"
+      node_name = "FW1_NODE"
+      consumer = {
+        l3_destination    = true
+        permit_logging    = false
+        logical_interface = "CONSUMER_INT"
+        redirect_policy = {
+          name   = "REDIR_CONSUMER"
+          tenant = "ABC"
+        }
+      }
+      provider = {
+        l3_destination    = true
+        permit_logging    = false
+        logical_interface = "PROVIDER_INT"
+        redirect_policy = {
+          name   = "REDIR_PROVIDER"
+          tenant = "ABC"
+        }
+      }
+    },
+    {
+      name      = "LB1"
+      node_name = "LB1_NODE"
+      consumer = {
+        logical_interface = "LB_CONSUMER_INT"
+        bridge_domain = {
+          name   = "BD_CONSUMER"
+          tenant = "ABC"
+        }
+      }
+      provider = {
+        logical_interface = "LB_PROVIDER_INT"
+        external_endpoint_group = {
+          tenant = "ABC"
+          l3out  = "L3OUT1"
+          name   = "EXTEPG1"
+          redistribute = {
+            bgp       = true
+            connected = true
+          }
+        }
+      }
+    }
+  ]
 }

--- a/modules/terraform-aci-device-selection-policy/main.tf
+++ b/modules/terraform-aci-device-selection-policy/main.tf
@@ -1,4 +1,67 @@
+locals {
+  # Determine if we're in multi-device mode based on whether devices list is provided
+  multi_device_mode = length(var.devices) > 0
+
+  # Build a map of devices keyed by node_name (or name if node_name not provided)
+  devices_map = {
+    for idx, device in var.devices : coalesce(device.node_name, device.name) => {
+      index     = idx
+      name      = device.name
+      tenant    = coalesce(device.tenant, var.tenant)
+      node_name = coalesce(device.node_name, device.name)
+      consumer = device.consumer != null ? {
+        l3_destination                                 = device.consumer.l3_destination != null ? device.consumer.l3_destination : false
+        permit_logging                                 = device.consumer.permit_logging != null ? device.consumer.permit_logging : false
+        logical_interface                              = device.consumer.logical_interface
+        redirect_policy                                = try(device.consumer.redirect_policy.name, "")
+        redirect_policy_tenant                         = coalesce(try(device.consumer.redirect_policy.tenant, null), device.tenant, var.tenant)
+        bridge_domain                                  = try(device.consumer.bridge_domain.name, "")
+        bridge_domain_tenant                           = coalesce(try(device.consumer.bridge_domain.tenant, null), device.tenant, var.tenant)
+        external_endpoint_group                        = try(device.consumer.external_endpoint_group.name, "")
+        external_endpoint_group_l3out                  = try(device.consumer.external_endpoint_group.l3out, "")
+        external_endpoint_group_tenant                 = coalesce(try(device.consumer.external_endpoint_group.tenant, null), device.tenant, var.tenant)
+        external_endpoint_group_redistribute_bgp       = try(device.consumer.external_endpoint_group.redistribute.bgp, false)
+        external_endpoint_group_redistribute_ospf      = try(device.consumer.external_endpoint_group.redistribute.ospf, false)
+        external_endpoint_group_redistribute_connected = try(device.consumer.external_endpoint_group.redistribute.connected, false)
+        external_endpoint_group_redistribute_static    = try(device.consumer.external_endpoint_group.redistribute.static, false)
+        service_epg_policy                             = device.consumer.service_epg_policy != null ? device.consumer.service_epg_policy : ""
+        custom_qos_policy                              = device.consumer.custom_qos_policy != null ? device.consumer.custom_qos_policy : ""
+      } : null
+      provider = device.provider != null ? {
+        l3_destination                                 = device.provider.l3_destination != null ? device.provider.l3_destination : false
+        permit_logging                                 = device.provider.permit_logging != null ? device.provider.permit_logging : false
+        logical_interface                              = device.provider.logical_interface
+        redirect_policy                                = try(device.provider.redirect_policy.name, "")
+        redirect_policy_tenant                         = coalesce(try(device.provider.redirect_policy.tenant, null), device.tenant, var.tenant)
+        bridge_domain                                  = try(device.provider.bridge_domain.name, "")
+        bridge_domain_tenant                           = coalesce(try(device.provider.bridge_domain.tenant, null), device.tenant, var.tenant)
+        external_endpoint_group                        = try(device.provider.external_endpoint_group.name, "")
+        external_endpoint_group_l3out                  = try(device.provider.external_endpoint_group.l3out, "")
+        external_endpoint_group_tenant                 = coalesce(try(device.provider.external_endpoint_group.tenant, null), device.tenant, var.tenant)
+        external_endpoint_group_redistribute_bgp       = try(device.provider.external_endpoint_group.redistribute.bgp, false)
+        external_endpoint_group_redistribute_ospf      = try(device.provider.external_endpoint_group.redistribute.ospf, false)
+        external_endpoint_group_redistribute_connected = try(device.provider.external_endpoint_group.redistribute.connected, false)
+        external_endpoint_group_redistribute_static    = try(device.provider.external_endpoint_group.redistribute.static, false)
+        service_epg_policy                             = device.provider.service_epg_policy != null ? device.provider.service_epg_policy : ""
+        custom_qos_policy                              = device.provider.custom_qos_policy != null ? device.provider.custom_qos_policy : ""
+      } : null
+      copy_service = device.copy_service != null ? {
+        l3_destination     = device.copy_service.l3_destination != null ? device.copy_service.l3_destination : false
+        permit_logging     = device.copy_service.permit_logging != null ? device.copy_service.permit_logging : false
+        logical_interface  = device.copy_service.logical_interface
+        service_epg_policy = device.copy_service.service_epg_policy != null ? device.copy_service.service_epg_policy : ""
+        custom_qos_policy  = device.copy_service.custom_qos_policy != null ? device.copy_service.custom_qos_policy : ""
+      } : null
+    }
+  }
+}
+
+# =============================================================================
+# Legacy single-device mode resources (when devices list is NOT provided)
+# =============================================================================
+
 resource "aci_rest_managed" "vnsLDevCtx" {
+  count      = local.multi_device_mode ? 0 : 1
   dn         = "uni/tn-${var.tenant}/ldevCtx-c-${var.contract}-g-${var.service_graph_template}-n-${var.node_name}"
   class_name = "vnsLDevCtx"
   content = {
@@ -9,7 +72,8 @@ resource "aci_rest_managed" "vnsLDevCtx" {
 }
 
 resource "aci_rest_managed" "vnsRsLDevCtxToLDev" {
-  dn         = "${aci_rest_managed.vnsLDevCtx.dn}/rsLDevCtxToLDev"
+  count      = local.multi_device_mode ? 0 : 1
+  dn         = "${aci_rest_managed.vnsLDevCtx[0].dn}/rsLDevCtxToLDev"
   class_name = "vnsRsLDevCtxToLDev"
   content = {
     tDn = "uni/tn-${var.tenant}/${var.sgt_device_tenant != var.tenant ? "lDevIf-[uni/tn-${var.sgt_device_tenant}/lDevVip-${var.sgt_device_name}]" : "lDevVip-${var.sgt_device_name}"}"
@@ -17,8 +81,8 @@ resource "aci_rest_managed" "vnsRsLDevCtxToLDev" {
 }
 
 resource "aci_rest_managed" "vnsLIfCtx_consumer" {
-  count      = var.consumer_logical_interface != "" ? 1 : 0
-  dn         = "${aci_rest_managed.vnsLDevCtx.dn}/lIfCtx-c-consumer"
+  count      = local.multi_device_mode ? 0 : (var.consumer_logical_interface != "" ? 1 : 0)
+  dn         = "${aci_rest_managed.vnsLDevCtx[0].dn}/lIfCtx-c-consumer"
   class_name = "vnsLIfCtx"
   content = {
     connNameOrLbl = "consumer",
@@ -28,7 +92,7 @@ resource "aci_rest_managed" "vnsLIfCtx_consumer" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToSvcRedirectPol_consumer" {
-  count      = var.consumer_logical_interface != "" && var.consumer_redirect_policy != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.consumer_logical_interface != "" && var.consumer_redirect_policy != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_consumer[0].dn}/rsLIfCtxToSvcRedirectPol"
   class_name = "vnsRsLIfCtxToSvcRedirectPol"
   content = {
@@ -37,7 +101,7 @@ resource "aci_rest_managed" "vnsRsLIfCtxToSvcRedirectPol_consumer" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToBD_consumer" {
-  count      = var.consumer_logical_interface != "" && var.consumer_bridge_domain != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.consumer_logical_interface != "" && var.consumer_bridge_domain != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_consumer[0].dn}/rsLIfCtxToBD"
   class_name = "vnsRsLIfCtxToBD"
   content = {
@@ -46,7 +110,7 @@ resource "aci_rest_managed" "vnsRsLIfCtxToBD_consumer" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToInstP_consumer" {
-  count      = var.consumer_logical_interface != "" && var.consumer_external_endpoint_group != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.consumer_logical_interface != "" && var.consumer_external_endpoint_group != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_consumer[0].dn}/rsLIfCtxToInstP"
   class_name = "vnsRsLIfCtxToInstP"
   content = {
@@ -56,16 +120,16 @@ resource "aci_rest_managed" "vnsRsLIfCtxToInstP_consumer" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToLIf_consumer" {
-  count      = var.consumer_logical_interface != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.consumer_logical_interface != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_consumer[0].dn}/rsLIfCtxToLIf"
   class_name = "vnsRsLIfCtxToLIf"
   content = {
-    tDn = "uni/tn-${var.tenant}/${var.sgt_device_tenant != var.tenant ? "lDevIf-[uni/tn-${var.sgt_device_tenant}/lDevVip-${var.sgt_device_name}]/lDevIfLIf-${var.provider_logical_interface}" : "lDevVip-${var.sgt_device_name}/lIf-${var.provider_logical_interface}"}"
+    tDn = "uni/tn-${var.tenant}/${var.sgt_device_tenant != var.tenant ? "lDevIf-[uni/tn-${var.sgt_device_tenant}/lDevVip-${var.sgt_device_name}]/lDevIfLIf-${var.consumer_logical_interface}" : "lDevVip-${var.sgt_device_name}/lIf-${var.consumer_logical_interface}"}"
   }
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_consumer" {
-  count      = var.consumer_logical_interface != "" && var.consumer_service_epg_policy != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.consumer_logical_interface != "" && var.consumer_service_epg_policy != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_consumer[0].dn}/rsLIfCtxToSvcEPgPol"
   class_name = "vnsRsLIfCtxToSvcEPgPol"
   content = {
@@ -74,7 +138,7 @@ resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_consumer" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToCustQosPol_consumer" {
-  count      = var.consumer_logical_interface != "" && var.consumer_custom_qos_policy != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.consumer_logical_interface != "" && var.consumer_custom_qos_policy != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_consumer[0].dn}/rsLIfCtxToCustQosPol"
   class_name = "vnsRsLIfCtxToCustQosPol"
   content = {
@@ -83,8 +147,8 @@ resource "aci_rest_managed" "vnsRsLIfCtxToCustQosPol_consumer" {
 }
 
 resource "aci_rest_managed" "vnsLIfCtx_provider" {
-  count      = var.provider_logical_interface != "" ? 1 : 0
-  dn         = "${aci_rest_managed.vnsLDevCtx.dn}/lIfCtx-c-provider"
+  count      = local.multi_device_mode ? 0 : (var.provider_logical_interface != "" ? 1 : 0)
+  dn         = "${aci_rest_managed.vnsLDevCtx[0].dn}/lIfCtx-c-provider"
   class_name = "vnsLIfCtx"
   content = {
     connNameOrLbl = "provider",
@@ -94,7 +158,7 @@ resource "aci_rest_managed" "vnsLIfCtx_provider" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToSvcRedirectPol_provider" {
-  count      = var.provider_logical_interface != "" && var.provider_redirect_policy != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.provider_logical_interface != "" && var.provider_redirect_policy != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_provider[0].dn}/rsLIfCtxToSvcRedirectPol"
   class_name = "vnsRsLIfCtxToSvcRedirectPol"
   content = {
@@ -103,7 +167,7 @@ resource "aci_rest_managed" "vnsRsLIfCtxToSvcRedirectPol_provider" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToBD_provider" {
-  count      = var.provider_logical_interface != "" && var.provider_bridge_domain != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.provider_logical_interface != "" && var.provider_bridge_domain != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_provider[0].dn}/rsLIfCtxToBD"
   class_name = "vnsRsLIfCtxToBD"
   content = {
@@ -112,7 +176,7 @@ resource "aci_rest_managed" "vnsRsLIfCtxToBD_provider" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToInstP_provider" {
-  count      = var.provider_logical_interface != "" && var.provider_external_endpoint_group != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.provider_logical_interface != "" && var.provider_external_endpoint_group != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_provider[0].dn}/rsLIfCtxToInstP"
   class_name = "vnsRsLIfCtxToInstP"
   content = {
@@ -122,7 +186,7 @@ resource "aci_rest_managed" "vnsRsLIfCtxToInstP_provider" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToLIf_provider" {
-  count      = var.provider_logical_interface != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.provider_logical_interface != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_provider[0].dn}/rsLIfCtxToLIf"
   class_name = "vnsRsLIfCtxToLIf"
   content = {
@@ -131,7 +195,7 @@ resource "aci_rest_managed" "vnsRsLIfCtxToLIf_provider" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_provider" {
-  count      = var.provider_logical_interface != "" && var.provider_service_epg_policy != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.provider_logical_interface != "" && var.provider_service_epg_policy != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_provider[0].dn}/rsLIfCtxToSvcEPgPol"
   class_name = "vnsRsLIfCtxToSvcEPgPol"
   content = {
@@ -140,7 +204,7 @@ resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_provider" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToCustQosPol_provider" {
-  count      = var.provider_logical_interface != "" && var.provider_custom_qos_policy != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.provider_logical_interface != "" && var.provider_custom_qos_policy != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_provider[0].dn}/rsLIfCtxToCustQosPol"
   class_name = "vnsRsLIfCtxToCustQosPol"
   content = {
@@ -149,8 +213,8 @@ resource "aci_rest_managed" "vnsRsLIfCtxToCustQosPol_provider" {
 }
 
 resource "aci_rest_managed" "vnsLIfCtx_copy" {
-  count      = var.copy_logical_interface != "" ? 1 : 0
-  dn         = "${aci_rest_managed.vnsLDevCtx.dn}/lIfCtx-c-copy"
+  count      = local.multi_device_mode ? 0 : (var.copy_logical_interface != "" ? 1 : 0)
+  dn         = "${aci_rest_managed.vnsLDevCtx[0].dn}/lIfCtx-c-copy"
   class_name = "vnsLIfCtx"
   content = {
     connNameOrLbl = "copy",
@@ -160,16 +224,16 @@ resource "aci_rest_managed" "vnsLIfCtx_copy" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToLIf_copy" {
-  count      = var.copy_logical_interface != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.copy_logical_interface != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_copy[0].dn}/rsLIfCtxToLIf"
   class_name = "vnsRsLIfCtxToLIf"
   content = {
-    tDn = "uni/tn-${var.sgt_device_tenant != var.tenant ? var.sgt_device_tenant : var.tenant}/lDevVip-${var.sgt_device_name}/lIf-${var.copy_logical_interface}"
+    tDn = "uni/tn-${var.tenant}/${var.sgt_device_tenant != var.tenant ? "lDevIf-[uni/tn-${var.sgt_device_tenant}/lDevVip-${var.sgt_device_name}]/lDevIfLIf-${var.copy_logical_interface}" : "lDevVip-${var.sgt_device_name}/lIf-${var.copy_logical_interface}"}"
   }
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_copy" {
-  count      = var.copy_logical_interface != "" && var.copy_service_epg_policy != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.copy_logical_interface != "" && var.copy_service_epg_policy != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_copy[0].dn}/rsLIfCtxToSvcEPgPol"
   class_name = "vnsRsLIfCtxToSvcEPgPol"
   content = {
@@ -178,10 +242,219 @@ resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_copy" {
 }
 
 resource "aci_rest_managed" "vnsRsLIfCtxToCustQosPol_copy" {
-  count      = var.copy_logical_interface != "" && var.copy_custom_qos_policy != "" ? 1 : 0
+  count      = local.multi_device_mode ? 0 : (var.copy_logical_interface != "" && var.copy_custom_qos_policy != "" ? 1 : 0)
   dn         = "${aci_rest_managed.vnsLIfCtx_copy[0].dn}/rsLIfCtxToCustQosPol"
   class_name = "vnsRsLIfCtxToCustQosPol"
   content = {
     tnQosCustomPolName = var.copy_custom_qos_policy
+  }
+}
+
+# =============================================================================
+# Multi-device mode resources (when devices list IS provided)
+# =============================================================================
+
+# vnsLDevCtx - One per device in the devices list
+resource "aci_rest_managed" "vnsLDevCtx_multi" {
+  for_each   = local.multi_device_mode ? local.devices_map : {}
+  dn         = "uni/tn-${var.tenant}/ldevCtx-c-${var.contract}-g-${var.service_graph_template}-n-${each.value.node_name}"
+  class_name = "vnsLDevCtx"
+  content = {
+    ctrctNameOrLbl = var.contract
+    graphNameOrLbl = var.service_graph_template
+    nodeNameOrLbl  = each.value.node_name
+  }
+}
+
+# vnsRsLDevCtxToLDev - Links device context to L4L7 device
+resource "aci_rest_managed" "vnsRsLDevCtxToLDev_multi" {
+  for_each   = local.multi_device_mode ? local.devices_map : {}
+  dn         = "${aci_rest_managed.vnsLDevCtx_multi[each.key].dn}/rsLDevCtxToLDev"
+  class_name = "vnsRsLDevCtxToLDev"
+  content = {
+    tDn = each.value.tenant == var.tenant ? "uni/tn-${var.tenant}/lDevVip-${each.value.name}" : "uni/tn-${var.tenant}/lDevIf-[uni/tn-${each.value.tenant}/lDevVip-${each.value.name}]"
+  }
+}
+
+# Consumer interface context for multi-device mode
+resource "aci_rest_managed" "vnsLIfCtx_consumer_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.consumer != null } : {}
+  dn         = "${aci_rest_managed.vnsLDevCtx_multi[each.key].dn}/lIfCtx-c-consumer"
+  class_name = "vnsLIfCtx"
+  content = {
+    connNameOrLbl = "consumer"
+    l3Dest        = each.value.consumer.l3_destination ? "yes" : "no"
+    permitLog     = each.value.consumer.permit_logging ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToSvcRedirectPol_consumer_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.consumer != null && v.consumer.redirect_policy != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_consumer_multi[each.key].dn}/rsLIfCtxToSvcRedirectPol"
+  class_name = "vnsRsLIfCtxToSvcRedirectPol"
+  content = {
+    tDn = "uni/tn-${each.value.consumer.redirect_policy_tenant}/svcCont/svcRedirectPol-${each.value.consumer.redirect_policy}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToBD_consumer_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.consumer != null && v.consumer.bridge_domain != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_consumer_multi[each.key].dn}/rsLIfCtxToBD"
+  class_name = "vnsRsLIfCtxToBD"
+  content = {
+    tDn = "uni/tn-${each.value.consumer.bridge_domain_tenant}/BD-${each.value.consumer.bridge_domain}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToInstP_consumer_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.consumer != null && v.consumer.external_endpoint_group != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_consumer_multi[each.key].dn}/rsLIfCtxToInstP"
+  class_name = "vnsRsLIfCtxToInstP"
+  content = {
+    redistribute = join(",", concat(
+      each.value.consumer.external_endpoint_group_redistribute_bgp ? ["bgp"] : [],
+      each.value.consumer.external_endpoint_group_redistribute_connected ? ["connected"] : [],
+      each.value.consumer.external_endpoint_group_redistribute_ospf ? ["ospf"] : [],
+      each.value.consumer.external_endpoint_group_redistribute_static ? ["static"] : []
+    ))
+    tDn = "uni/tn-${each.value.consumer.external_endpoint_group_tenant}/out-${each.value.consumer.external_endpoint_group_l3out}/instP-${each.value.consumer.external_endpoint_group}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToLIf_consumer_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.consumer != null } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_consumer_multi[each.key].dn}/rsLIfCtxToLIf"
+  class_name = "vnsRsLIfCtxToLIf"
+  content = {
+    tDn = each.value.tenant == var.tenant ? "uni/tn-${var.tenant}/lDevVip-${each.value.name}/lIf-${each.value.consumer.logical_interface}" : "uni/tn-${var.tenant}/lDevIf-[uni/tn-${each.value.tenant}/lDevVip-${each.value.name}]/lDevIfLIf-${each.value.consumer.logical_interface}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_consumer_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.consumer != null && v.consumer.service_epg_policy != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_consumer_multi[each.key].dn}/rsLIfCtxToSvcEPgPol"
+  class_name = "vnsRsLIfCtxToSvcEPgPol"
+  content = {
+    tDn = "uni/tn-${var.tenant}/svcCont/svcEPgPol-${each.value.consumer.service_epg_policy}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToCustQosPol_consumer_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.consumer != null && v.consumer.custom_qos_policy != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_consumer_multi[each.key].dn}/rsLIfCtxToCustQosPol"
+  class_name = "vnsRsLIfCtxToCustQosPol"
+  content = {
+    tnQosCustomPolName = each.value.consumer.custom_qos_policy
+  }
+}
+
+# Provider interface context for multi-device mode
+resource "aci_rest_managed" "vnsLIfCtx_provider_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.provider != null } : {}
+  dn         = "${aci_rest_managed.vnsLDevCtx_multi[each.key].dn}/lIfCtx-c-provider"
+  class_name = "vnsLIfCtx"
+  content = {
+    connNameOrLbl = "provider"
+    l3Dest        = each.value.provider.l3_destination ? "yes" : "no"
+    permitLog     = each.value.provider.permit_logging ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToSvcRedirectPol_provider_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.provider != null && v.provider.redirect_policy != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_provider_multi[each.key].dn}/rsLIfCtxToSvcRedirectPol"
+  class_name = "vnsRsLIfCtxToSvcRedirectPol"
+  content = {
+    tDn = "uni/tn-${each.value.provider.redirect_policy_tenant}/svcCont/svcRedirectPol-${each.value.provider.redirect_policy}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToBD_provider_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.provider != null && v.provider.bridge_domain != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_provider_multi[each.key].dn}/rsLIfCtxToBD"
+  class_name = "vnsRsLIfCtxToBD"
+  content = {
+    tDn = "uni/tn-${each.value.provider.bridge_domain_tenant}/BD-${each.value.provider.bridge_domain}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToInstP_provider_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.provider != null && v.provider.external_endpoint_group != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_provider_multi[each.key].dn}/rsLIfCtxToInstP"
+  class_name = "vnsRsLIfCtxToInstP"
+  content = {
+    redistribute = join(",", concat(
+      each.value.provider.external_endpoint_group_redistribute_bgp ? ["bgp"] : [],
+      each.value.provider.external_endpoint_group_redistribute_connected ? ["connected"] : [],
+      each.value.provider.external_endpoint_group_redistribute_ospf ? ["ospf"] : [],
+      each.value.provider.external_endpoint_group_redistribute_static ? ["static"] : []
+    ))
+    tDn = "uni/tn-${each.value.provider.external_endpoint_group_tenant}/out-${each.value.provider.external_endpoint_group_l3out}/instP-${each.value.provider.external_endpoint_group}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToLIf_provider_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.provider != null } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_provider_multi[each.key].dn}/rsLIfCtxToLIf"
+  class_name = "vnsRsLIfCtxToLIf"
+  content = {
+    tDn = each.value.tenant == var.tenant ? "uni/tn-${var.tenant}/lDevVip-${each.value.name}/lIf-${each.value.provider.logical_interface}" : "uni/tn-${var.tenant}/lDevIf-[uni/tn-${each.value.tenant}/lDevVip-${each.value.name}]/lDevIfLIf-${each.value.provider.logical_interface}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_provider_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.provider != null && v.provider.service_epg_policy != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_provider_multi[each.key].dn}/rsLIfCtxToSvcEPgPol"
+  class_name = "vnsRsLIfCtxToSvcEPgPol"
+  content = {
+    tDn = "uni/tn-${var.tenant}/svcCont/svcEPgPol-${each.value.provider.service_epg_policy}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToCustQosPol_provider_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.provider != null && v.provider.custom_qos_policy != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_provider_multi[each.key].dn}/rsLIfCtxToCustQosPol"
+  class_name = "vnsRsLIfCtxToCustQosPol"
+  content = {
+    tnQosCustomPolName = each.value.provider.custom_qos_policy
+  }
+}
+
+# Copy service interface context for multi-device mode
+resource "aci_rest_managed" "vnsLIfCtx_copy_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.copy_service != null } : {}
+  dn         = "${aci_rest_managed.vnsLDevCtx_multi[each.key].dn}/lIfCtx-c-copy"
+  class_name = "vnsLIfCtx"
+  content = {
+    connNameOrLbl = "copy"
+    l3Dest        = each.value.copy_service.l3_destination ? "yes" : "no"
+    permitLog     = each.value.copy_service.permit_logging ? "yes" : "no"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToLIf_copy_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.copy_service != null } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_copy_multi[each.key].dn}/rsLIfCtxToLIf"
+  class_name = "vnsRsLIfCtxToLIf"
+  content = {
+    tDn = each.value.tenant == var.tenant ? "uni/tn-${var.tenant}/lDevVip-${each.value.name}/lIf-${each.value.copy_service.logical_interface}" : "uni/tn-${var.tenant}/lDevIf-[uni/tn-${each.value.tenant}/lDevVip-${each.value.name}]/lDevIfLIf-${each.value.copy_service.logical_interface}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToSvcEPgPol_copy_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.copy_service != null && v.copy_service.service_epg_policy != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_copy_multi[each.key].dn}/rsLIfCtxToSvcEPgPol"
+  class_name = "vnsRsLIfCtxToSvcEPgPol"
+  content = {
+    tDn = "uni/tn-${var.tenant}/svcCont/svcEPgPol-${each.value.copy_service.service_epg_policy}"
+  }
+}
+
+resource "aci_rest_managed" "vnsRsLIfCtxToCustQosPol_copy_multi" {
+  for_each   = local.multi_device_mode ? { for k, v in local.devices_map : k => v if v.copy_service != null && v.copy_service.custom_qos_policy != "" } : {}
+  dn         = "${aci_rest_managed.vnsLIfCtx_copy_multi[each.key].dn}/rsLIfCtxToCustQosPol"
+  class_name = "vnsRsLIfCtxToCustQosPol"
+  content = {
+    tnQosCustomPolName = each.value.copy_service.custom_qos_policy
   }
 }

--- a/modules/terraform-aci-device-selection-policy/outputs.tf
+++ b/modules/terraform-aci-device-selection-policy/outputs.tf
@@ -1,4 +1,4 @@
 output "dn" {
-  value       = aci_rest_managed.vnsLDevCtx.id
-  description = "Distinguished name of `vnsLDevCtx` object."
+  value       = length(var.devices) > 0 ? values(aci_rest_managed.vnsLDevCtx_multi)[*].id : (length(aci_rest_managed.vnsLDevCtx) > 0 ? [aci_rest_managed.vnsLDevCtx[0].id] : [])
+  description = "Distinguished name of `vnsLDevCtx` object(s). Returns a list of DNs."
 }

--- a/modules/terraform-aci-device-selection-policy/variables.tf
+++ b/modules/terraform-aci-device-selection-policy/variables.tf
@@ -40,8 +40,9 @@ variable "sgt_device_tenant" {
 }
 
 variable "sgt_device_name" {
-  description = "Device name."
+  description = "Device name. Required for legacy single-device mode, not used when `devices` is specified."
   type        = string
+  default     = ""
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.sgt_device_name))
@@ -428,5 +429,88 @@ variable "copy_service_epg_policy_tenant" {
   validation {
     condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.copy_service_epg_policy_tenant))
     error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
+variable "devices" {
+  description = "List of devices for multi-device device selection policy. When specified, legacy single-device variables (device_name, node_name, consumer, provider, copy_service at root level) are ignored."
+  type = list(object({
+    name      = string
+    tenant    = optional(string)
+    node_name = optional(string)
+    consumer = optional(object({
+      l3_destination    = optional(bool)
+      permit_logging    = optional(bool)
+      logical_interface = string
+      redirect_policy = optional(object({
+        name   = string
+        tenant = optional(string)
+      }))
+      bridge_domain = optional(object({
+        name   = string
+        tenant = optional(string)
+      }))
+      external_endpoint_group = optional(object({
+        tenant = optional(string)
+        l3out  = string
+        name   = string
+        redistribute = optional(object({
+          bgp       = optional(bool)
+          ospf      = optional(bool)
+          connected = optional(bool)
+          static    = optional(bool)
+        }))
+      }))
+      service_epg_policy = optional(string)
+      custom_qos_policy  = optional(string)
+    }))
+    provider = optional(object({
+      l3_destination    = optional(bool)
+      permit_logging    = optional(bool)
+      logical_interface = string
+      redirect_policy = optional(object({
+        name   = string
+        tenant = optional(string)
+      }))
+      bridge_domain = optional(object({
+        name   = string
+        tenant = optional(string)
+      }))
+      external_endpoint_group = optional(object({
+        tenant = optional(string)
+        l3out  = string
+        name   = string
+        redistribute = optional(object({
+          bgp       = optional(bool)
+          ospf      = optional(bool)
+          connected = optional(bool)
+          static    = optional(bool)
+        }))
+      }))
+      service_epg_policy = optional(string)
+      custom_qos_policy  = optional(string)
+    }))
+    copy_service = optional(object({
+      l3_destination     = optional(bool)
+      permit_logging     = optional(bool)
+      logical_interface  = string
+      service_epg_policy = optional(string)
+      custom_qos_policy  = optional(string)
+    }))
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for device in var.devices : can(regex("^[a-zA-Z0-9_.:-]{1,64}$", device.name))
+    ])
+    error_message = "Device name must match: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. 1-64 characters."
+  }
+
+  validation {
+    condition = alltrue([
+      for device in var.devices : device.node_name == null || can(regex("^[a-zA-Z0-9_.:-]{1,64}$", device.node_name))
+    ])
+    error_message = "Device node_name must match: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. 1-64 characters."
   }
 }


### PR DESCRIPTION
Add support for Device Selection Policy multi-nodes ensuring backwards compatibility.

Data model tested:
```yaml
--- 
apic:
  tenants:
    - name: ABC
      services:
        l4l7_devices:
          - name: Node-1
            concrete_devices:
              - name: PhyNode1
                interfaces:
                - name: PhyNode1_If1
                  node_id: 101
                  port: 21
            logical_interfaces:
              - name: PhyNode1_v814
                vlan: 814
                concrete_interfaces:
                  - device: PhyNode1
                    interface_name: PhyNode1_If1
          - name: Node-2
            concrete_devices:
              - name: PhyNode2
                interfaces:
                - name: PhyNode2_If1
                  node_id: 101
                  port: 22
            logical_interfaces:
              - name: PhyNode2_v815
                vlan: 815
                concrete_interfaces:
                  - device: PhyNode2
                    interface_name: PhyNode2_If1
          - name: CopyDevice-1
            copy_device: true
            function: None
            service_type: COPY
            concrete_devices:
              - name: PhyCopyDevice1
                interfaces:
                - name: PhyCopyDevice1_If1
                  node_id: 101
                  port: 23
            logical_interfaces:
              - name: CP_Iface_v816
                vlan: 816
                concrete_interfaces:
                  - device: PhyCopyDevice1
                    interface_name: PhyCopyDevice1_If1
          - name: CopyDevice-2
            copy_device: true
            function: None
            service_type: COPY
            concrete_devices:
              - name: PhyCopyDevice2
                interfaces:
                - name: PhyCopyDevice2_If1
                  node_id: 101
                  port: 24
            logical_interfaces:
              - name: CP_Iface_v817
                vlan: 817
                concrete_interfaces:
                  - device: PhyCopyDevice2
                    interface_name: PhyCopyDevice2_If1
        service_graph_templates:
          - name: PBR_2
            devices:
              - name: Node-1
              - name: Node-2
              - name: CopyDevice-1
            connections:
              - consumer_node: EPG-Consumer
                provider_node: Node-1
                copy_node: CopyDevice-1
              - consumer_node: Node-1
                provider_node: Node-2
                copy_node: CopyDevice-1
              - consumer_node: Node-2
                provider_node: EPG-Provider
        device_selection_policies:
          - contract: PBR_2_CT0
            service_graph_template: PBR_2
            devices:
              - name: Node-1
                node_name: N1_NodeName
                consumer:
                  logical_interface: PhyNode1_v814
                  l3_destination: false
                  permit_logging: true
                  service_epg_policy: SEP
                  custom_qos_policy: CQoSP
                  redirect_policy:
                    name: RP1
                  bridge_domain:
                    name: BD1
                    tenant: ABC
                provider:
                  logical_interface: PhyNode1_v814
              - name: Node-2
                node_name: N2_NodeName
                consumer:
                  logical_interface: PhyNode2_v815
                  l3_destination: true
                  permit_logging: true
                  service_epg_policy: SEP
                  custom_qos_policy: CQoSP
                  redirect_policy:
                    name: RP1
                    tenant: ABC
                  external_endpoint_group:
                    name: EEPG1
                    l3out: L3OUT1
                    tenant: ABC
                    redistribute:
                      bgp: true
                      ospf: true
                      connected: true
                      static: true
                provider:
                  logical_interface: PhyNode2_v815
              - name: CopyDevice-1
                node_name: CP1_NodeName
                copy_service:
                  logical_interface: CP_Iface_v816
                  l3_destination: false
                  service_epg_policy: SEP2
                  custom_qos_policy: CQoSP2

```