### PR TITLE
Removing undeletable objects in the Spine IPG and Switch Policy Groups.

### DIFF
--- a/modules/terraform-aci-access-leaf-switch-policy-group/main.tf
+++ b/modules/terraform-aci-access-leaf-switch-policy-group/main.tf
@@ -13,6 +13,9 @@ resource "aci_rest_managed" "infraRsTopoctrlFwdScaleProfPol" {
   content = {
     tnTopoctrlFwdScaleProfilePolName = var.forwarding_scale_policy
   }
+  content_on_destroy = {
+    tnTopoctrlFwdScaleProfilePolName = ""
+  }
 }
 
 resource "aci_rest_managed" "infraRsBfdIpv4InstPol" {
@@ -21,6 +24,9 @@ resource "aci_rest_managed" "infraRsBfdIpv4InstPol" {
   class_name = "infraRsBfdIpv4InstPol"
   content = {
     tnBfdIpv4InstPolName = var.bfd_ipv4_policy
+  }
+  content_on_destroy = {
+    tnBfdIpv4InstPolName = ""
   }
 }
 
@@ -31,6 +37,9 @@ resource "aci_rest_managed" "infraRsBfdIpv6InstPol" {
   content = {
     tnBfdIpv6InstPolName = var.bfd_ipv6_policy
   }
+  content_on_destroy = {
+    tnBfdIpv6InstPolName = ""
+  }
 }
 
 resource "aci_rest_managed" "infraRsLeafPGrpToCdpIfPol" {
@@ -40,6 +49,9 @@ resource "aci_rest_managed" "infraRsLeafPGrpToCdpIfPol" {
   content = {
     tnCdpIfPolName = var.cdp_policy
   }
+  content_on_destroy = {
+    tnCdpIfPolName = ""
+  }
 }
 
 resource "aci_rest_managed" "infraRsLeafPGrpToLldpIfPol" {
@@ -48,5 +60,8 @@ resource "aci_rest_managed" "infraRsLeafPGrpToLldpIfPol" {
   class_name = "infraRsLeafPGrpToLldpIfPol"
   content = {
     tnLldpIfPolName = var.lldp_policy
+  }
+  content_on_destroy = {
+    tnLldpIfPolName = ""
   }
 }

--- a/modules/terraform-aci-access-spine-interface-policy-group/main.tf
+++ b/modules/terraform-aci-access-spine-interface-policy-group/main.tf
@@ -13,6 +13,9 @@ resource "aci_rest_managed" "infraRsHIfPol" {
   content = {
     tnFabricHIfPolName = var.link_level_policy
   }
+  content_on_destroy = {
+    tnFabricHIfPolName = ""
+  }
 }
 
 resource "aci_rest_managed" "infraRsCdpIfPol" {
@@ -22,6 +25,9 @@ resource "aci_rest_managed" "infraRsCdpIfPol" {
   content = {
     tnCdpIfPolName = var.cdp_policy
   }
+  content_on_destroy = {
+    tnCdpIfPolName = ""
+  }
 }
 
 resource "aci_rest_managed" "infraRsMacsecIfPol" {
@@ -30,6 +36,9 @@ resource "aci_rest_managed" "infraRsMacsecIfPol" {
   class_name = "infraRsMacsecIfPol"
   content = {
     tnMacsecIfPolName = var.macsec_interface_policy
+  }
+  content_on_destroy = {
+    tnMacsecIfPolName = ""
   }
 }
 

--- a/modules/terraform-aci-access-spine-switch-policy-group/main.tf
+++ b/modules/terraform-aci-access-spine-switch-policy-group/main.tf
@@ -14,6 +14,9 @@ resource "aci_rest_managed" "infraRsBfdIpv4InstPol" {
   content = {
     tnBfdIpv4InstPolName = var.bfd_ipv4_policy
   }
+  content_on_destroy = {
+    tnBfdIpv4InstPolName = ""
+  }
 }
 
 resource "aci_rest_managed" "infraRsBfdIpv6InstPol" {
@@ -22,6 +25,9 @@ resource "aci_rest_managed" "infraRsBfdIpv6InstPol" {
   class_name = "infraRsSpineBfdIpv6InstPol"
   content = {
     tnBfdIpv6InstPolName = var.bfd_ipv6_policy
+  }
+  content_on_destroy = {
+    tnBfdIpv6InstPolName = ""
   }
 }
 
@@ -32,6 +38,9 @@ resource "aci_rest_managed" "infraRsSpinePGrpToCdpIfPol" {
   content = {
     tnCdpIfPolName = var.cdp_policy
   }
+  content_on_destroy = {
+    tnCdpIfPolName = ""
+  }
 }
 
 resource "aci_rest_managed" "infraRsSpinePGrpToLldpIfPol" {
@@ -40,6 +49,9 @@ resource "aci_rest_managed" "infraRsSpinePGrpToLldpIfPol" {
   class_name = "infraRsSpinePGrpToLldpIfPol"
   content = {
     tnLldpIfPolName = var.lldp_policy
+  }
+  content_on_destroy = {
+    tnLldpIfPolName = ""
   }
 }
 


### PR DESCRIPTION
Description

This pull request introduces the possibility of removing Rs objects associated to an Spine Interface Policy Group and Switch Policy Groups (leaf and spine)  using terraform.

-Motivation

Prior the change, it was possible to associate an access policy (e.g. Link Level Policy) to an IPG or Switch Policy Group using terraform, but when trying to remove the same policy from the PG terraform recognized the operation but the APIC kept the relationship making impossible to remove the policy even when the data model (input data) didn't contain the policy anymore.