### PR TITLE
fix: resolve AAEP endpoint_groups defaults for mode and deployment_im…

### DIFF
--- a/aci_access_policies.tf
+++ b/aci_access_policies.tf
@@ -52,7 +52,7 @@ module "aci_aaep" {
   routed_domains      = [for dom in try(each.value.routed_domains, []) : "${dom}${local.defaults.apic.access_policies.routed_domains.name_suffix}"]
   vmware_vmm_domains  = try(each.value.vmware_vmm_domains, [])
   nutanix_vmm_domains = try(each.value.nutanix_vmm_domains, [])
-  endpoint_groups     = [for epg in try(each.value.endpoint_groups, []) : {
+  endpoint_groups = [for epg in try(each.value.endpoint_groups, []) : {
     tenant               = epg.tenant
     application_profile  = epg.application_profile
     endpoint_group       = epg.endpoint_group

--- a/aci_access_policies.tf
+++ b/aci_access_policies.tf
@@ -52,7 +52,16 @@ module "aci_aaep" {
   routed_domains      = [for dom in try(each.value.routed_domains, []) : "${dom}${local.defaults.apic.access_policies.routed_domains.name_suffix}"]
   vmware_vmm_domains  = try(each.value.vmware_vmm_domains, [])
   nutanix_vmm_domains = try(each.value.nutanix_vmm_domains, [])
-  endpoint_groups     = try(each.value.endpoint_groups, [])
+  endpoint_groups     = [for epg in try(each.value.endpoint_groups, []) : {
+    tenant               = epg.tenant
+    application_profile  = epg.application_profile
+    endpoint_group       = epg.endpoint_group
+    vlan                 = try(epg.vlan, null)
+    primary_vlan         = try(epg.primary_vlan, null)
+    secondary_vlan       = try(epg.secondary_vlan, null)
+    mode                 = try(epg.mode, local.defaults.apic.access_policies.aaeps.endpoint_groups.mode)
+    deployment_immediacy = try(epg.deployment_immediacy, local.defaults.apic.access_policies.aaeps.endpoint_groups.deployment_immediacy)
+  }]
 
   depends_on = [
     module.aci_physical_domain,


### PR DESCRIPTION
The endpoint_groups list was passed raw to the terraform-aci-aaep child module, bypassing local.defaults entirely. The child module's hardcoded optional() defaults (lazy/regular) always won, making the defaults.apic.access_policies.aaeps.endpoint_groups.* keys in defaults.yaml unreachable.

Replace the raw passthrough with an explicit for loop that resolves mode and deployment_immediacy against local.defaults.