### PR TITLE
Correct NP.BGP.name max length

### DIFF
--- a/modules/terraform-aci-l3out-node-profile/variables.tf
+++ b/modules/terraform-aci-l3out-node-profile/variables.tf
@@ -350,8 +350,8 @@ variable "bgp_protocol_profile_name" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.bgp_protocol_profile_name))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,16}$", var.bgp_protocol_profile_name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 16."
   }
 }
 


### PR DESCRIPTION
Correct Node Profile BGP name max length from 64 to 16.

```hcl
│ Error: Invalid value for variable
│
│   on .terraform/modules/aci/aci_tenants.tf line 1197, in module "aci_l3out_node_profile_manual":
│ 1197:   bgp_protocol_profile_name = each.value.bgp_protocol_profile_name
│     ├────────────────
│     │ var.bgp_protocol_profile_name is "BGP_TOO_LONG_NAME"
│
│ Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 16.
│
│ This was checked by the validation rule at terraform-aci-nac-aci/modules/terraform-aci-l3out-node-profile/variables.tf:352,3-13.
```
