### PR TITLE
Fix SGT resources

### DIFF
--- a/modules/terraform-aci-service-graph-template/main.tf
+++ b/modules/terraform-aci-service-graph-template/main.tf
@@ -366,11 +366,11 @@ resource "aci_rest_managed" "vnsRsAbsCopyConnection_multi" {
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_Consumer_multi" {
   for_each   = local.multi_device_mode ? local.connections_map : {}
-  dn         = each.value.consumer_node == "EPG-Consumer" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-consumer]"
+  dn         = each.value.consumer_node == "EPG-Consumer" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T2.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-consumer]"
   class_name = "vnsRsAbsConnectionConns"
   annotation = var.annotation
   content = {
-    tDn = each.value.consumer_node == "EPG-Consumer" ? aci_rest_managed.vnsAbsTermConn_T1.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-consumer"
+    tDn = each.value.consumer_node == "EPG-Consumer" ? aci_rest_managed.vnsAbsTermConn_T2.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-consumer"
   }
   depends_on = [
     aci_rest_managed.vnsRsAbsCopyConnection_multi
@@ -379,11 +379,11 @@ resource "aci_rest_managed" "vnsRsAbsConnectionConns_Consumer_multi" {
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_Provider_multi" {
   for_each   = local.multi_device_mode ? local.connections_map : {}
-  dn         = each.value.provider_node == "EPG-Provider" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T2.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-provider]"
+  dn         = each.value.provider_node == "EPG-Provider" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-provider]"
   class_name = "vnsRsAbsConnectionConns"
   annotation = var.annotation
   content = {
-    tDn = each.value.provider_node == "EPG-Provider" ? aci_rest_managed.vnsAbsTermConn_T2.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-provider"
+    tDn = each.value.provider_node == "EPG-Provider" ? aci_rest_managed.vnsAbsTermConn_T1.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-provider"
   }
   depends_on = [
     aci_rest_managed.vnsRsAbsCopyConnection_multi

--- a/modules/terraform-aci-service-graph-template/main.tf
+++ b/modules/terraform-aci-service-graph-template/main.tf
@@ -14,8 +14,34 @@ locals {
     }
   }
 
+  # Lookup: each connection keyed by its consumer_node. Used to walk the chain
+  # starting from "EPG-Consumer" and following provider_node → next connection.
+  conn_by_consumer = { for conn in var.connections : conn.consumer_node => conn }
+
+  # Chain walk (unrolled, max 10 steps — service graphs practically never exceed this).
+  # Each step retrieves the connection whose consumer_node matches the previous
+  # step's provider_node. `try` returns null when the chain terminates naturally
+  # (last connection's provider_node is "EPG-Provider", which has no consumer_node key).
+  _walk_1  = try(local.conn_by_consumer["EPG-Consumer"], null)
+  _walk_2  = local._walk_1 == null ? null : try(local.conn_by_consumer[local._walk_1.provider_node], null)
+  _walk_3  = local._walk_2 == null ? null : try(local.conn_by_consumer[local._walk_2.provider_node], null)
+  _walk_4  = local._walk_3 == null ? null : try(local.conn_by_consumer[local._walk_3.provider_node], null)
+  _walk_5  = local._walk_4 == null ? null : try(local.conn_by_consumer[local._walk_4.provider_node], null)
+  _walk_6  = local._walk_5 == null ? null : try(local.conn_by_consumer[local._walk_5.provider_node], null)
+  _walk_7  = local._walk_6 == null ? null : try(local.conn_by_consumer[local._walk_6.provider_node], null)
+  _walk_8  = local._walk_7 == null ? null : try(local.conn_by_consumer[local._walk_7.provider_node], null)
+  _walk_9  = local._walk_8 == null ? null : try(local.conn_by_consumer[local._walk_8.provider_node], null)
+  _walk_10 = local._walk_9 == null ? null : try(local.conn_by_consumer[local._walk_9.provider_node], null)
+
+  chain_ordered = [
+    for c in [
+      local._walk_1, local._walk_2, local._walk_3, local._walk_4, local._walk_5,
+      local._walk_6, local._walk_7, local._walk_8, local._walk_9, local._walk_10,
+    ] : c if c != null
+  ]
+
   connections_map = {
-    for idx, conn in var.connections : "C${idx + 1}" => {
+    for idx, conn in local.chain_ordered : "C${idx + 1}" => {
       index          = idx
       name           = "C${idx + 1}"
       consumer_node  = conn.consumer_node

--- a/modules/terraform-aci-service-graph-template/main.tf
+++ b/modules/terraform-aci-service-graph-template/main.tf
@@ -366,11 +366,11 @@ resource "aci_rest_managed" "vnsRsAbsCopyConnection_multi" {
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_Consumer_multi" {
   for_each   = local.multi_device_mode ? local.connections_map : {}
-  dn         = each.value.consumer_node == "EPG-Consumer" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T2.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-consumer]"
+  dn         = each.value.consumer_node == "EPG-Consumer" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-provider]"
   class_name = "vnsRsAbsConnectionConns"
   annotation = var.annotation
   content = {
-    tDn = each.value.consumer_node == "EPG-Consumer" ? aci_rest_managed.vnsAbsTermConn_T2.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-consumer"
+    tDn = each.value.consumer_node == "EPG-Consumer" ? aci_rest_managed.vnsAbsTermConn_T1.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_consumer_node}/AbsFConn-provider"
   }
   depends_on = [
     aci_rest_managed.vnsRsAbsCopyConnection_multi
@@ -379,11 +379,11 @@ resource "aci_rest_managed" "vnsRsAbsConnectionConns_Consumer_multi" {
 
 resource "aci_rest_managed" "vnsRsAbsConnectionConns_Provider_multi" {
   for_each   = local.multi_device_mode ? local.connections_map : {}
-  dn         = each.value.provider_node == "EPG-Provider" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T1.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-provider]"
+  dn         = each.value.provider_node == "EPG-Provider" ? "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsTermConn_T2.dn}]" : "${aci_rest_managed.vnsAbsConnection_multi[each.key].dn}/rsabsConnectionConns-[${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-consumer]"
   class_name = "vnsRsAbsConnectionConns"
   annotation = var.annotation
   content = {
-    tDn = each.value.provider_node == "EPG-Provider" ? aci_rest_managed.vnsAbsTermConn_T1.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-provider"
+    tDn = each.value.provider_node == "EPG-Provider" ? aci_rest_managed.vnsAbsTermConn_T2.dn : "${aci_rest_managed.vnsAbsGraph.dn}/AbsNode-${each.value.resolved_provider_node}/AbsFConn-consumer"
   }
   depends_on = [
     aci_rest_managed.vnsRsAbsCopyConnection_multi

--- a/modules/terraform-aci-service-graph-template/variables.tf
+++ b/modules/terraform-aci-service-graph-template/variables.tf
@@ -213,4 +213,30 @@ variable "connections" {
     ])
     error_message = "Connection adjacency_type must be one of: `L2`, `L3`."
   }
+
+  validation {
+    condition     = length(var.connections) <= 10
+    error_message = "A service graph supports at most 10 connections (module walks the chain via an unrolled loop of depth 10)."
+  }
+
+  validation {
+    condition = length(var.connections) == 0 || length([
+      for conn in var.connections : conn if conn.consumer_node == "EPG-Consumer"
+    ]) == 1
+    error_message = "connections must include exactly one entry with `consumer_node: EPG-Consumer` (the chain start)."
+  }
+
+  validation {
+    condition = length(var.connections) == 0 || length([
+      for conn in var.connections : conn if conn.provider_node == "EPG-Provider"
+    ]) == 1
+    error_message = "connections must include exactly one entry with `provider_node: EPG-Provider` (the chain end)."
+  }
+
+  validation {
+    condition = length(distinct([
+      for conn in var.connections : conn.consumer_node
+    ])) == length(var.connections)
+    error_message = "Each `consumer_node` value must be unique across connections (service graph chain is linear; a node cannot appear as the consumer side of more than one connection)."
+  }
 }


### PR DESCRIPTION
Aligning dn to the ones generated by GUI:

- `vnsRsAbsConnectionConns.tDn`: consumer <> T1
- `vnsRsAbsConnectionConns.tDn`: provider <> T2

This updates the `vnsRsAbsConnectionConns` resources only, not the entire SGT definition:

```hcl
Terraform will perform the following actions:

  # module.aci.module.aci_service_graph_template["ABC/PBR_1"].aci_rest_managed.vnsRsAbsConnectionConns_Consumer_multi["C1"] must be replaced
-/+ resource "aci_rest_managed" "vnsRsAbsConnectionConns_Consumer_multi" {
      ~ content     = {
          ~ "tDn" = "uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeCon-T1/AbsTConn" -> "uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeProv-T2/AbsTConn"
        }
      ~ dn          = "uni/tn-ABC/AbsGraph-PBR_1/AbsConnection-C1/rsabsConnectionConns-[uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeCon-T1/AbsTConn]" -> "uni/tn-ABC/AbsGraph-PBR_1/AbsConnection-C1/rsabsConnectionConns-[uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeProv-T2/AbsTConn]" # forces replacement
      ~ id          = "uni/tn-ABC/AbsGraph-PBR_1/AbsConnection-C1/rsabsConnectionConns-[uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeCon-T1/AbsTConn]" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

  # module.aci.module.aci_service_graph_template["ABC/PBR_1"].aci_rest_managed.vnsRsAbsConnectionConns_Provider_multi["C2"] must be replaced
-/+ resource "aci_rest_managed" "vnsRsAbsConnectionConns_Provider_multi" {
      ~ content     = {
          ~ "tDn" = "uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeProv-T2/AbsTConn" -> "uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeCon-T1/AbsTConn"
        }
      ~ dn          = "uni/tn-ABC/AbsGraph-PBR_1/AbsConnection-C2/rsabsConnectionConns-[uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeProv-T2/AbsTConn]" -> "uni/tn-ABC/AbsGraph-PBR_1/AbsConnection-C2/rsabsConnectionConns-[uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeCon-T1/AbsTConn]" # forces replacement
      ~ id          = "uni/tn-ABC/AbsGraph-PBR_1/AbsConnection-C2/rsabsConnectionConns-[uni/tn-ABC/AbsGraph-PBR_1/AbsTermNodeProv-T2/AbsTConn]" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

  # module.aci.module.aci_service_graph_template["DEF/SGT1"].aci_rest_managed.vnsRsAbsConnectionConns_Consumer_multi["C1"] must be replaced
-/+ resource "aci_rest_managed" "vnsRsAbsConnectionConns_Consumer_multi" {
      ~ content     = {
          ~ "tDn" = "uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeCon-T1/AbsTConn" -> "uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeProv-T2/AbsTConn"
        }
      ~ dn          = "uni/tn-DEF/AbsGraph-SGT1/AbsConnection-C1/rsabsConnectionConns-[uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeCon-T1/AbsTConn]" -> "uni/tn-DEF/AbsGraph-SGT1/AbsConnection-C1/rsabsConnectionConns-[uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeProv-T2/AbsTConn]" # forces replacement
      ~ id          = "uni/tn-DEF/AbsGraph-SGT1/AbsConnection-C1/rsabsConnectionConns-[uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeCon-T1/AbsTConn]" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

  # module.aci.module.aci_service_graph_template["DEF/SGT1"].aci_rest_managed.vnsRsAbsConnectionConns_Provider_multi["C2"] must be replaced
-/+ resource "aci_rest_managed" "vnsRsAbsConnectionConns_Provider_multi" {
      ~ content     = {
          ~ "tDn" = "uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeProv-T2/AbsTConn" -> "uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeCon-T1/AbsTConn"
        }
      ~ dn          = "uni/tn-DEF/AbsGraph-SGT1/AbsConnection-C2/rsabsConnectionConns-[uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeProv-T2/AbsTConn]" -> "uni/tn-DEF/AbsGraph-SGT1/AbsConnection-C2/rsabsConnectionConns-[uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeCon-T1/AbsTConn]" # forces replacement
      ~ id          = "uni/tn-DEF/AbsGraph-SGT1/AbsConnection-C2/rsabsConnectionConns-[uni/tn-DEF/AbsGraph-SGT1/AbsTermNodeProv-T2/AbsTConn]" -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 4 to add, 0 to change, 4 to destroy.
```