### PR TITLE
Adding Remote Leaf Pod Redundancy Policy Support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -773,6 +773,10 @@ repos:
       - id: terraform-docs-system
         args: ["./modules/terraform-aci-redirect-policy/examples/complete"]
       - id: terraform-docs-system
+        args: ["./modules/terraform-aci-remote-leaf-pod-redundancy-policy"]
+      - id: terraform-docs-system
+        args: ["./modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete"]
+      - id: terraform-docs-system
         args: ["./modules/terraform-aci-remote-location"]
       - id: terraform-docs-system
         args: ["./modules/terraform-aci-remote-location/examples/complete"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New Features
 
-- Add support for Remote Leaf Pod Redundancy Policy (`remote_leaf_pod_redundancy_policy` with `enable_remote_leaf_policy` and `preemption`)
+- Add support for Remote Leaf Pod Redundancy Policy (`remote_leaf_pod_redundancy_policy` with `enable_policy` and `preemption`)
 - BREAKING CHANGE: Move old `leaked_internal_prefixes` (class leakInternalSubnet) to `leaked_internal_subnets` and add support for new `leaked_internal_prefixes` (class leakInternalPrefix) in a VRF leaking configuration
 - BREAKING CHANGE: Add support for configuring custom monitoring policy. Previous configuration needs to be moved to explicit `common` monitoring policy
 - BREAKING CHANGE: Update default values for various management access policy attributes (`aes256_gcm`, `curve25519_sha256`, `curve25519_sha256_libssh`,`dh14_sha256`, `dh16_sha512`, `ecdh_sha2_nistp256`, `ecdh_sha2_nistp384`, `ecdh_sha2_nistp521`, `tlsv1_1`, `chacha`, `hmac_sha1`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New Features
 
+- Add support for Remote Leaf Pod Redundancy Policy (`remote_leaf_pod_redundancy_policy` with `enable_remote_leaf_policy` and `preemption`)
 - BREAKING CHANGE: Move old `leaked_internal_prefixes` (class leakInternalSubnet) to `leaked_internal_subnets` and add support for new `leaked_internal_prefixes` (class leakInternalPrefix) in a VRF leaking configuration
 - BREAKING CHANGE: Add support for configuring custom monitoring policy. Previous configuration needs to be moved to explicit `common` monitoring policy
 - BREAKING CHANGE: Update default values for various management access policy attributes (`aes256_gcm`, `curve25519_sha256`, `curve25519_sha256_libssh`,`dh14_sha256`, `dh16_sha512`, `ecdh_sha2_nistp256`, `ecdh_sha2_nistp384`, `ecdh_sha2_nistp521`, `tlsv1_1`, `chacha`, `hmac_sha1`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### New Features
 
-- Add support for Remote Leaf Pod Redundancy Policy (`remote_leaf_pod_redundancy_policy` with `enable_policy` and `preemption`)
 - BREAKING CHANGE: Move old `leaked_internal_prefixes` (class leakInternalSubnet) to `leaked_internal_subnets` and add support for new `leaked_internal_prefixes` (class leakInternalPrefix) in a VRF leaking configuration
 - BREAKING CHANGE: Add support for configuring custom monitoring policy. Previous configuration needs to be moved to explicit `common` monitoring policy
 - BREAKING CHANGE: Update default values for various management access policy attributes (`aes256_gcm`, `curve25519_sha256`, `curve25519_sha256_libssh`,`dh14_sha256`, `dh16_sha512`, `ecdh_sha2_nistp256`, `ecdh_sha2_nistp384`, `ecdh_sha2_nistp521`, `tlsv1_1`, `chacha`, `hmac_sha1`)

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Additional example repositories:
 | <a name="module_aci_redirect_backup_policy"></a> [aci\_redirect\_backup\_policy](#module\_aci\_redirect\_backup\_policy) | ./modules/terraform-aci-redirect-backup-policy | n/a |
 | <a name="module_aci_redirect_health_group"></a> [aci\_redirect\_health\_group](#module\_aci\_redirect\_health\_group) | ./modules/terraform-aci-redirect-health-group | n/a |
 | <a name="module_aci_redirect_policy"></a> [aci\_redirect\_policy](#module\_aci\_redirect\_policy) | ./modules/terraform-aci-redirect-policy | n/a |
+| <a name="module_aci_remote_leaf_pod_redundancy_policy"></a> [aci\_remote\_leaf\_pod\_redundancy\_policy](#module\_aci\_remote\_leaf\_pod\_redundancy\_policy) | ./modules/terraform-aci-remote-leaf-pod-redundancy-policy | n/a |
 | <a name="module_aci_remote_location"></a> [aci\_remote\_location](#module\_aci\_remote\_location) | ./modules/terraform-aci-remote-location | n/a |
 | <a name="module_aci_rogue_endpoint_control"></a> [aci\_rogue\_endpoint\_control](#module\_aci\_rogue\_endpoint\_control) | ./modules/terraform-aci-rogue-endpoint-control | n/a |
 | <a name="module_aci_route_control_route_map"></a> [aci\_route\_control\_route\_map](#module\_aci\_route\_control\_route\_map) | ./modules/terraform-aci-route-control-route-map | n/a |

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -70,6 +70,14 @@ module "aci_port_tracking" {
   include_apic = try(local.fabric_policies.port_tracking.include_apic, null)
 }
 
+module "aci_remote_leaf_pod_redundancy_policy" {
+  source = "./modules/terraform-aci-remote-leaf-pod-redundancy-policy"
+
+  count                     = local.modules.aci_remote_leaf_pod_redundancy_policy == true && var.manage_fabric_policies ? 1 : 0
+  enable_remote_leaf_policy = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.enable_remote_leaf_policy, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.enable_remote_leaf_policy)
+  enable_preemption         = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.enable_preemption, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.enable_preemption)
+}
+
 module "aci_ptp" {
   source = "./modules/terraform-aci-ptp"
 

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -73,9 +73,9 @@ module "aci_port_tracking" {
 module "aci_remote_leaf_pod_redundancy_policy" {
   source = "./modules/terraform-aci-remote-leaf-pod-redundancy-policy"
 
-  count                     = local.modules.aci_remote_leaf_pod_redundancy_policy == true && var.manage_fabric_policies ? 1 : 0
-  enable_remote_leaf_policy = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.enable_remote_leaf_policy, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.enable_remote_leaf_policy)
-  preemption                = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.preemption, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.preemption)
+  count         = local.modules.aci_remote_leaf_pod_redundancy_policy == true && var.manage_fabric_policies ? 1 : 0
+  enable_policy = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.enable_policy, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.enable_policy)
+  preemption    = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.preemption, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.preemption)
 }
 
 module "aci_ptp" {

--- a/aci_fabric_policies.tf
+++ b/aci_fabric_policies.tf
@@ -75,7 +75,7 @@ module "aci_remote_leaf_pod_redundancy_policy" {
 
   count                     = local.modules.aci_remote_leaf_pod_redundancy_policy == true && var.manage_fabric_policies ? 1 : 0
   enable_remote_leaf_policy = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.enable_remote_leaf_policy, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.enable_remote_leaf_policy)
-  enable_preemption         = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.enable_preemption, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.enable_preemption)
+  preemption                = try(local.fabric_policies.remote_leaf_pod_redundancy_policy.preemption, local.defaults.apic.fabric_policies.remote_leaf_pod_redundancy_policy.preemption)
 }
 
 module "aci_ptp" {

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -61,6 +61,9 @@ defaults:
         delay: 120
         min_links: 0
         include_apic: false
+      remote_leaf_pod_redundancy_policy:
+        enable_remote_leaf_policy: false
+        enable_preemption: false
       ptp:
         admin_state: false
         global_domain: 0

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -62,7 +62,7 @@ defaults:
         min_links: 0
         include_apic: false
       remote_leaf_pod_redundancy_policy:
-        enable_remote_leaf_policy: false
+        enable_policy: false
         preemption: false
       ptp:
         admin_state: false

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -63,7 +63,7 @@ defaults:
         include_apic: false
       remote_leaf_pod_redundancy_policy:
         enable_remote_leaf_policy: false
-        enable_preemption: false
+        preemption: false
       ptp:
         admin_state: false
         global_domain: 0

--- a/defaults/modules.yaml
+++ b/defaults/modules.yaml
@@ -156,6 +156,7 @@ modules:
   aci_redirect_backup_policy: true
   aci_redirect_health_group: true
   aci_redirect_policy: true
+  aci_remote_leaf_pod_redundancy_policy: true
   aci_remote_location: true
   aci_remote_vxlan_fabrics: true
   aci_rogue_endpoint_control: true

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/.terraform-docs.yml
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/.terraform-docs.yml
@@ -1,0 +1,34 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Terraform ACI Remote Leaf Pod Redundancy Policy Module
+
+  Manages ACI Remote Leaf Pod Redundancy Policy
+
+  Location in GUI:
+  `System` » `System Settings` » `Remote Leaf POD Redundancy`
+
+  ## Examples
+
+  ```hcl
+  {{ include "./examples/complete/main.tf" }}
+  ```
+
+  {{ .Requirements }}
+
+  {{ .Providers }}
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Resources }}
+
+output:
+  file: README.md
+  mode: replace
+
+sort:
+  enabled: false

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/README.md
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/README.md
@@ -1,0 +1,52 @@
+<!-- BEGIN_TF_DOCS -->
+# Terraform ACI Remote Leaf Pod Redundancy Policy Module
+
+Manages ACI Remote Leaf Pod Redundancy Policy
+
+Location in GUI:
+`System` » `System Settings` » `Remote Leaf POD Redundancy`
+
+## Examples
+
+```hcl
+module "aci_remote_leaf_pod_redundancy_policy" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
+  version = ">= 0.8.0"
+
+  enable_remote_leaf_policy = true
+  enable_preemption         = true
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_enable_remote_leaf_policy"></a> [enable\_remote\_leaf\_policy](#input\_enable\_remote\_leaf\_policy) | Enable Remote Leaf Pod Redundancy Policy. | `bool` | `false` | no |
+| <a name="input_enable_preemption"></a> [enable\_preemption](#input\_enable\_preemption) | Enable Pod Redundancy Preemption. | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dn"></a> [dn](#output\_dn) | Distinguished name of `infraRlPodRedPol` object. |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aci_rest_managed.infraRlPodRedPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/README.md
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/README.md
@@ -13,8 +13,8 @@ module "aci_remote_leaf_pod_redundancy_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
   version = ">= 0.8.0"
 
-  enable_remote_leaf_policy = true
-  preemption                = true
+  enable_policy = true
+  preemption    = true
 }
 ```
 
@@ -35,7 +35,7 @@ module "aci_remote_leaf_pod_redundancy_policy" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_enable_remote_leaf_policy"></a> [enable\_remote\_leaf\_policy](#input\_enable\_remote\_leaf\_policy) | Enable Remote Leaf Pod Redundancy Policy. | `bool` | `false` | no |
+| <a name="input_enable_policy"></a> [enable\_policy](#input\_enable\_policy) | Enable Remote Leaf Pod Redundancy Policy. | `bool` | `false` | no |
 | <a name="input_preemption"></a> [preemption](#input\_preemption) | Enable Pod Redundancy Preemption. | `bool` | `false` | no |
 
 ## Outputs

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/README.md
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/README.md
@@ -14,7 +14,7 @@ module "aci_remote_leaf_pod_redundancy_policy" {
   version = ">= 0.8.0"
 
   enable_remote_leaf_policy = true
-  enable_preemption         = true
+  preemption                = true
 }
 ```
 
@@ -36,7 +36,7 @@ module "aci_remote_leaf_pod_redundancy_policy" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_enable_remote_leaf_policy"></a> [enable\_remote\_leaf\_policy](#input\_enable\_remote\_leaf\_policy) | Enable Remote Leaf Pod Redundancy Policy. | `bool` | `false` | no |
-| <a name="input_enable_preemption"></a> [enable\_preemption](#input\_enable\_preemption) | Enable Pod Redundancy Preemption. | `bool` | `false` | no |
+| <a name="input_preemption"></a> [preemption](#input\_preemption) | Enable Pod Redundancy Preemption. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/README.md
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/README.md
@@ -11,7 +11,7 @@ Location in GUI:
 ```hcl
 module "aci_remote_leaf_pod_redundancy_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
-  version = ">= 0.8.0"
+  version = "> 2.0.0"
 
   enable_policy = true
   preemption    = true
@@ -22,7 +22,7 @@ module "aci_remote_leaf_pod_redundancy_policy" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
 
 ## Providers

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/.terraform-docs.yml
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/.terraform-docs.yml
@@ -1,0 +1,24 @@
+version: '>= 0.14.0'
+
+formatter: markdown table
+
+content: |-
+  # Remote Leaf Pod Redundancy Policy Example
+
+  To run this example you need to execute:
+
+  ```bash
+  $ terraform init
+  $ terraform plan
+  $ terraform apply
+  ```
+
+  Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+  ```hcl
+  {{ include "./main.tf" }}
+  ```
+
+output:
+  file: README.md
+  mode: replace

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/README.md
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/README.md
@@ -1,0 +1,23 @@
+<!-- BEGIN_TF_DOCS -->
+# Remote Leaf Pod Redundancy Policy Example
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example will create resources. Resources can be destroyed with `terraform destroy`.
+
+```hcl
+module "aci_remote_leaf_pod_redundancy_policy" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
+  version = ">= 0.8.0"
+
+  enable_remote_leaf_policy = true
+  enable_preemption         = true
+}
+```
+<!-- END_TF_DOCS -->

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/README.md
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/README.md
@@ -14,7 +14,7 @@ Note that this example will create resources. Resources can be destroyed with `t
 ```hcl
 module "aci_remote_leaf_pod_redundancy_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
-  version = ">= 0.8.0"
+  version = "> 2.0.0"
 
   enable_policy = true
   preemption    = true

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/README.md
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/README.md
@@ -17,7 +17,7 @@ module "aci_remote_leaf_pod_redundancy_policy" {
   version = ">= 0.8.0"
 
   enable_remote_leaf_policy = true
-  enable_preemption         = true
+  preemption                = true
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/README.md
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/README.md
@@ -16,8 +16,8 @@ module "aci_remote_leaf_pod_redundancy_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
   version = ">= 0.8.0"
 
-  enable_remote_leaf_policy = true
-  preemption                = true
+  enable_policy = true
+  preemption    = true
 }
 ```
 <!-- END_TF_DOCS -->

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/main.tf
@@ -1,0 +1,7 @@
+module "aci_remote_leaf_pod_redundancy_policy" {
+  source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
+  version = ">= 0.8.0"
+
+  enable_remote_leaf_policy = true
+  enable_preemption         = true
+}

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/main.tf
@@ -3,5 +3,5 @@ module "aci_remote_leaf_pod_redundancy_policy" {
   version = ">= 0.8.0"
 
   enable_remote_leaf_policy = true
-  enable_preemption         = true
+  preemption                = true
 }

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/main.tf
@@ -2,6 +2,6 @@ module "aci_remote_leaf_pod_redundancy_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
   version = ">= 0.8.0"
 
-  enable_remote_leaf_policy = true
-  preemption                = true
+  enable_policy = true
+  preemption    = true
 }

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/main.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/main.tf
@@ -1,6 +1,6 @@
 module "aci_remote_leaf_pod_redundancy_policy" {
   source  = "netascode/nac-aci/aci//modules/terraform-aci-remote-leaf-pod-redundancy-policy"
-  version = ">= 0.8.0"
+  version = "> 2.0.0"
 
   enable_policy = true
   preemption    = true

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/versions.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/versions.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/examples/complete/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aci = {

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/main.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/main.tf
@@ -1,0 +1,9 @@
+resource "aci_rest_managed" "infraRlPodRedPol" {
+  dn         = "uni/infra/rlpodred"
+  class_name = "infraRlPodRedPol"
+  content = {
+    name                   = "default"
+    enableRlPodRedPol      = var.enable_remote_leaf_policy == true ? "yes" : "no"
+    enablePodRedPreemption = var.enable_preemption == true ? "yes" : "no"
+  }
+}

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/main.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/main.tf
@@ -4,6 +4,6 @@ resource "aci_rest_managed" "infraRlPodRedPol" {
   content = {
     name                   = "default"
     enableRlPodRedPol      = var.enable_remote_leaf_policy == true ? "yes" : "no"
-    enablePodRedPreemption = var.enable_preemption == true ? "yes" : "no"
+    enablePodRedPreemption = var.preemption == true ? "yes" : "no"
   }
 }

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/main.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/main.tf
@@ -3,7 +3,7 @@ resource "aci_rest_managed" "infraRlPodRedPol" {
   class_name = "infraRlPodRedPol"
   content = {
     name                   = "default"
-    enableRlPodRedPol      = var.enable_remote_leaf_policy == true ? "yes" : "no"
+    enableRlPodRedPol      = var.enable_policy == true ? "yes" : "no"
     enablePodRedPreemption = var.preemption == true ? "yes" : "no"
   }
 }

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/outputs.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/outputs.tf
@@ -1,0 +1,4 @@
+output "dn" {
+  value       = aci_rest_managed.infraRlPodRedPol.id
+  description = "Distinguished name of `infraRlPodRedPol` object."
+}

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/variables.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/variables.tf
@@ -1,0 +1,11 @@
+variable "enable_remote_leaf_policy" {
+  description = "Enable Remote Leaf Pod Redundancy Policy."
+  type        = bool
+  default     = false
+}
+
+variable "enable_preemption" {
+  description = "Enable Pod Redundancy Preemption."
+  type        = bool
+  default     = false
+}

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/variables.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/variables.tf
@@ -1,4 +1,4 @@
-variable "enable_remote_leaf_policy" {
+variable "enable_policy" {
   description = "Enable Remote Leaf Pod Redundancy Policy."
   type        = bool
   default     = false

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/variables.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/variables.tf
@@ -4,7 +4,7 @@ variable "enable_remote_leaf_policy" {
   default     = false
 }
 
-variable "enable_preemption" {
+variable "preemption" {
   description = "Enable Pod Redundancy Preemption."
   type        = bool
   default     = false

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/versions.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/versions.tf
@@ -1,0 +1,11 @@
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aci = {
+      source  = "CiscoDevNet/aci"
+      version = ">= 2.0.0"
+    }
+  }
+}

--- a/modules/terraform-aci-remote-leaf-pod-redundancy-policy/versions.tf
+++ b/modules/terraform-aci-remote-leaf-pod-redundancy-policy/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aci = {


### PR DESCRIPTION
Description

This pull request introduces support for the system setting Remote Leaf Pod Redundancy Policy.

-Motivation

Currently the AaC does not support this policy configuration. End-to-end support is being added.