### PR TITLE
## support for interface policy group monitoring policy ##

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Additional example repositories:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | >= 2.3.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Additional example repositories:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_local"></a> [local](#provider\_local) | >= 2.3.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.9.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Resources

--- a/aci_access_policies.tf
+++ b/aci_access_policies.tf
@@ -527,6 +527,7 @@ module "aci_access_leaf_interface_policy_group" {
   storm_control_policy               = try("${each.value.storm_control_policy}${local.defaults.apic.access_policies.interface_policies.storm_control_policies.name_suffix}", "")
   port_security_policy               = try("${each.value.port_security_policy}${local.defaults.apic.access_policies.interface_policies.port_security_policies.name_suffix}", "")
   priority_flow_control_policy       = try("${each.value.priority_flow_control_policy}${local.defaults.apic.access_policies.interface_policies.priority_flow_control_policies.name_suffix}", "")
+  monitoring_policy                  = try("${each.value.monitoring_policy}${local.defaults.apic.access_policies.monitoring.policies.name_suffix}", "")
   port_channel_policy                = try("${each.value.port_channel_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_policies.name_suffix}", "")
   port_channel_member_name           = try(each.value.port_channel_member_name, "${each.value.name}${local.defaults.apic.access_policies.leaf_interface_policy_groups.name_suffix}")
   port_channel_member_policy         = try("${each.value.port_channel_member_policy}${local.defaults.apic.access_policies.interface_policies.port_channel_member_policies.name_suffix}", "")
@@ -548,6 +549,7 @@ module "aci_access_leaf_interface_policy_group" {
     module.aci_storm_control_policy,
     module.aci_port_security_policy,
     module.aci_priority_flow_control_policy,
+    module.aci_access_monitoring_policy,
     module.aci_port_channel_policy,
     module.aci_port_channel_member_policy,
     module.aci_netflow_monitor,

--- a/modules/terraform-aci-access-leaf-interface-policy-group/README.md
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/README.md
@@ -24,6 +24,7 @@ module "aci_access_leaf_interface_policy_group" {
   mcp_policy                 = "MCP-ON"
   l2_policy                  = "PORT-LOCAL"
   storm_control_policy       = "10P"
+  monitoring_policy          = "MONITOR-POL1"
   port_channel_policy        = "LACP"
   port_channel_member_name   = "PG-Member"
   port_channel_member_policy = "FAST"
@@ -35,14 +36,14 @@ module "aci_access_leaf_interface_policy_group" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0 |
+| <a name="requirement_aci"></a> [aci](#requirement\_aci) | >= 2.19.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.0.0 |
+| <a name="provider_aci"></a> [aci](#provider\_aci) | >= 2.19.0 |
 
 ## Inputs
 
@@ -64,6 +65,7 @@ module "aci_access_leaf_interface_policy_group" {
 | <a name="input_storm_control_policy"></a> [storm\_control\_policy](#input\_storm\_control\_policy) | Storm control policy name. | `string` | `""` | no |
 | <a name="input_port_security_policy"></a> [port\_security\_policy](#input\_port\_security\_policy) | Port security policy name. | `string` | `""` | no |
 | <a name="input_priority_flow_control_policy"></a> [priority\_flow\_control\_policy](#input\_priority\_flow\_control\_policy) | Priority flow control policy name. | `string` | `""` | no |
+| <a name="input_monitoring_policy"></a> [monitoring\_policy](#input\_monitoring\_policy) | Monitoring policy name. | `string` | `""` | no |
 | <a name="input_port_channel_policy"></a> [port\_channel\_policy](#input\_port\_channel\_policy) | Port channel policy name. | `string` | `""` | no |
 | <a name="input_port_channel_member_name"></a> [port\_channel\_member\_name](#input\_port\_channel\_member\_name) | Port channel member name. | `string` | `""` | no |
 | <a name="input_port_channel_member_policy"></a> [port\_channel\_member\_policy](#input\_port\_channel\_member\_policy) | Port channel member policy name. | `string` | `""` | no |
@@ -93,6 +95,7 @@ module "aci_access_leaf_interface_policy_group" {
 | [aci_rest_managed.infraRsLldpIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsMacsecIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsMcpIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
+| [aci_rest_managed.infraRsMonIfInfraPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsNetflowMonitorPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsQosEgressDppIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |
 | [aci_rest_managed.infraRsQosIngressDppIfPol](https://registry.terraform.io/providers/CiscoDevNet/aci/latest/docs/resources/rest_managed) | resource |

--- a/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/README.md
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/README.md
@@ -27,6 +27,7 @@ module "aci_access_leaf_interface_policy_group" {
   mcp_policy                 = "MCP-ON"
   l2_policy                  = "PORT-LOCAL"
   storm_control_policy       = "10P"
+  monitoring_policy          = "MONITOR-POL1"
   port_channel_policy        = "LACP"
   port_channel_member_name   = "PG-Member"
   port_channel_member_policy = "FAST"

--- a/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/main.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/examples/complete/main.tf
@@ -13,6 +13,7 @@ module "aci_access_leaf_interface_policy_group" {
   mcp_policy                 = "MCP-ON"
   l2_policy                  = "PORT-LOCAL"
   storm_control_policy       = "10P"
+  monitoring_policy          = "MONITOR-POL1"
   port_channel_policy        = "LACP"
   port_channel_member_name   = "PG-Member"
   port_channel_member_policy = "FAST"

--- a/modules/terraform-aci-access-leaf-interface-policy-group/main.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/main.tf
@@ -147,6 +147,18 @@ resource "aci_rest_managed" "infraRsQosPfcIfPol" {
   }
 }
 
+resource "aci_rest_managed" "infraRsMonIfInfraPol" {
+  count      = var.type != "breakout" && var.monitoring_policy != "" ? 1 : 0
+  dn         = "${aci_rest_managed.infraAccGrp.dn}/rsmonIfInfraPol"
+  class_name = "infraRsMonIfInfraPol"
+  content = {
+    tnMonInfraPolName = var.monitoring_policy
+  }
+  content_on_destroy = {
+    tnMonInfraPolName = ""
+  }
+}
+
 resource "aci_rest_managed" "infraRsLacpPol" {
   count      = (var.type == "vpc" || var.type == "pc") && var.port_channel_policy != "" ? 1 : 0
   dn         = "${aci_rest_managed.infraAccGrp.dn}/rslacpPol"

--- a/modules/terraform-aci-access-leaf-interface-policy-group/variables.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/variables.tf
@@ -174,6 +174,17 @@ variable "priority_flow_control_policy" {
   }
 }
 
+variable "monitoring_policy" {
+  description = "Monitoring policy name."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.monitoring_policy))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+  }
+}
+
 variable "port_channel_policy" {
   description = "Port channel policy name."
   type        = string

--- a/modules/terraform-aci-access-leaf-interface-policy-group/versions.tf
+++ b/modules/terraform-aci-access-leaf-interface-policy-group/versions.tf
@@ -1,11 +1,11 @@
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.8.0"
 
   required_providers {
     aci = {
       source  = "CiscoDevNet/aci"
-      version = ">= 2.0.0"
+      version = ">= 2.19.0"
     }
   }
 }


### PR DESCRIPTION
test config 

```
apic:
  access_policies:
    monitoring:
      policies:
        - name: MONITOR_POL_1
        - name: MONITOR_POL_2

    leaf_interface_policy_groups:
      # Access port with a monitoring policy
      - name: ACCESS_MON_POL
        type: access
        monitoring_policy: MONITOR_POL_1

      # VPC with a monitoring policy
      - name: VPC_MON_POL
        type: vpc
        monitoring_policy: MONITOR_POL_2

      # PC (Port Channel) with a monitoring policy
      - name: PC_MON_POL
        type: pc
        monitoring_policy: MONITOR_POL_1

      # Access port with no monitoring policy (baseline, no infraRsMonIfInfraPol expected)
      - name: ACCESS_NO_MON_POL
        type: access

```