### PR TITLE
feat: expose `defaults_yaml` output for CLI-driven HCP Terraform / Terraform Enterprise workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Additional example repositories:
 | Name | Description |
 |------|-------------|
 | <a name="output_default_values"></a> [default\_values](#output\_default\_values) | All default values. |
+| <a name="output_defaults_yaml"></a> [defaults\_yaml](#output\_defaults\_yaml) | All default values in YAML string (same content as `write_default_values_file`). |
 | <a name="output_model"></a> [model](#output\_model) | Full model. |
 
 ## Providers

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,12 @@ output "default_values" {
   value       = local.defaults
 }
 
+output "defaults_yaml" {
+  description = "All default values in YAML string (same content as `write_default_values_file`)."
+  value       = local.defaults_string
+  sensitive   = true
+}
+
 output "model" {
   description = "Full model."
   value       = local.model


### PR DESCRIPTION
Closes #423 

### What

Adds a new module output `defaults_yaml` that returns `local.defaults_string` — the exact YAML content already written by `local_sensitive_file.defaults` when `write_default_values_file` is set.

### Why

CLI-driven HCP Terraform runs execute on remote Agents. `local_sensitive_file` writes to the Agent's ephemeral filesystem, unreachable from the CI runner invoking `terraform`. Consumers currently have to either:

- lose key order via `yamlencode(module.x.default_values)`, or
- re-implement the `yaml_merge` at the root against internal `.terraform/modules/...` paths.

Surfacing the string preserves the canonical schema-declaration order produced by `provider::utils::yaml_merge` and lets pipelines extract it with `terraform output -raw defaults_yaml`.

### Change

```diff
 output "default_values" {
   description = "All default values."
   value       = local.defaults
 }

+output "defaults_yaml" {
+  description = "All default values in YAML string (same content as `write_default_values_file`)."
+  value       = local.defaults_string
+  sensitive   = true
+}
+
 output "model" {
   description = "Full model."
   value       = local.model
 }
```

### Testing

- `terraform plan` / `apply` using this module still succeeds.
- `terraform output -raw defaults_yaml > defaults_from_tf_output.yaml` produces output byte-identical to `write_default_values_file`'s content (verified via `diff` & `md5`).

### Backwards compatibility

Purely additive. No existing outputs, variables, or resources changed.

### Docs

Updated `README.md` outputs table.
