### PR TITLE
Fix variable validations

### DIFF
--- a/modules/terraform-aci-access-span-destination-group/variables.tf
+++ b/modules/terraform-aci-access-span-destination-group/variables.tf
@@ -167,8 +167,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-application-profile/variables.tf
+++ b/modules/terraform-aci-application-profile/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -35,8 +35,8 @@ variable "alias" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.alias))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.alias))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-bfd-interface-policy/variables.tf
+++ b/modules/terraform-aci-bfd-interface-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 variable "name" {

--- a/modules/terraform-aci-bfd-multihop-node-policy/variables.tf
+++ b/modules/terraform-aci-bfd-multihop-node-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 variable "name" {

--- a/modules/terraform-aci-bgp-address-family-context-policy/variables.tf
+++ b/modules/terraform-aci-bgp-address-family-context-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-bgp-best-path-policy/variables.tf
+++ b/modules/terraform-aci-bgp-best-path-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-bgp-peer-prefix-policy/variables.tf
+++ b/modules/terraform-aci-bgp-peer-prefix-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-bgp-route-summarization-policy/variables.tf
+++ b/modules/terraform-aci-bgp-route-summarization-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-bgp-timer-policy/variables.tf
+++ b/modules/terraform-aci-bgp-timer-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-bridge-domain/variables.tf
+++ b/modules/terraform-aci-bridge-domain/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -13,8 +13,8 @@ variable "name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 
@@ -63,8 +63,8 @@ variable "alias" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.alias))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.alias))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -220,6 +220,11 @@ variable "unknown_ipv6_multicast" {
 variable "vrf" {
   description = "VRF name."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.vrf))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
+  }
 }
 
 variable "igmp_interface_policy" {

--- a/modules/terraform-aci-contract/variables.tf
+++ b/modules/terraform-aci-contract/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-data-plane-policing-policy/variables.tf
+++ b/modules/terraform-aci-data-plane-policing-policy/variables.tf
@@ -14,8 +14,8 @@ variable "tenant" {
   default     = null
 
   validation {
-    condition     = var.tenant == null ? true : can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = var.tenant == null ? true : can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-device-selection-policy/variables.tf
+++ b/modules/terraform-aci-device-selection-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-dhcp-option-policy/variables.tf
+++ b/modules/terraform-aci-dhcp-option-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-dhcp-relay-policy/variables.tf
+++ b/modules/terraform-aci-dhcp-relay-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-eigrp-interface-policy/variables.tf
+++ b/modules/terraform-aci-eigrp-interface-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-endpoint-group/variables.tf
+++ b/modules/terraform-aci-endpoint-group/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -45,8 +45,8 @@ variable "alias" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.alias))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.alias))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -112,8 +112,8 @@ variable "bridge_domain" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.bridge_domain))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.bridge_domain))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-endpoint-ip-tag-policy/variables.tf
+++ b/modules/terraform-aci-endpoint-ip-tag-policy/variables.tf
@@ -8,8 +8,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -19,8 +19,8 @@ variable "vrf" {
   default     = null
 
   validation {
-    condition     = var.vrf == null || can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.vrf))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = var.vrf == null || can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.vrf))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-endpoint-mac-tag-policy/variables.tf
+++ b/modules/terraform-aci-endpoint-mac-tag-policy/variables.tf
@@ -15,8 +15,8 @@ variable "bridge_domain" {
   default     = "all"
 
   validation {
-    condition     = var.bridge_domain == "all" || can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.bridge_domain))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = var.bridge_domain == "all" || can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.bridge_domain))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 
@@ -25,8 +25,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -36,8 +36,8 @@ variable "vrf" {
   default     = null
 
   validation {
-    condition     = var.vrf == null || can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.vrf))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = var.vrf == null || can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.vrf))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-endpoint-retention-policy/variables.tf
+++ b/modules/terraform-aci-endpoint-retention-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-endpoint-security-group/variables.tf
+++ b/modules/terraform-aci-endpoint-security-group/variables.tf
@@ -13,8 +13,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -55,8 +55,8 @@ variable "vrf" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.vrf))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.vrf))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-external-endpoint-group/variables.tf
+++ b/modules/terraform-aci-external-endpoint-group/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-fabric-span-destination-group/variables.tf
+++ b/modules/terraform-aci-fabric-span-destination-group/variables.tf
@@ -98,8 +98,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-filter/variables.tf
+++ b/modules/terraform-aci-filter/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-hsrp-group-policy/variables.tf
+++ b/modules/terraform-aci-hsrp-group-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-hsrp-interface-policy/variables.tf
+++ b/modules/terraform-aci-hsrp-interface-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-igmp-interface-policy/variables.tf
+++ b/modules/terraform-aci-igmp-interface-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-igmp-snooping-policy/variables.tf
+++ b/modules/terraform-aci-igmp-snooping-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-imported-contract/variables.tf
+++ b/modules/terraform-aci-imported-contract/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-imported-l4l7-device/variables.tf
+++ b/modules/terraform-aci-imported-l4l7-device/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-inband-endpoint-group/variables.tf
+++ b/modules/terraform-aci-inband-endpoint-group/variables.tf
@@ -23,8 +23,8 @@ variable "bridge_domain" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.bridge_domain))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.bridge_domain))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-infra-dhcp-relay-policy/variables.tf
+++ b/modules/terraform-aci-infra-dhcp-relay-policy/variables.tf
@@ -4,8 +4,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-ip-sla-policy/variables.tf
+++ b/modules/terraform-aci-ip-sla-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-l3out-interface-profile/variables.tf
+++ b/modules/terraform-aci-l3out-interface-profile/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-l3out-node-profile/variables.tf
+++ b/modules/terraform-aci-l3out-node-profile/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-l3out/variables.tf
+++ b/modules/terraform-aci-l3out/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -66,8 +66,8 @@ variable "vrf" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.vrf))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.vrf))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-l4l7-device/variables.tf
+++ b/modules/terraform-aci-l4l7-device/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-match-rule/variables.tf
+++ b/modules/terraform-aci-match-rule/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-multicast-route-map/variables.tf
+++ b/modules/terraform-aci-multicast-route-map/variables.tf
@@ -4,8 +4,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-nd-interface-policy/variables.tf
+++ b/modules/terraform-aci-nd-interface-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 variable "name" {

--- a/modules/terraform-aci-nd-ra-prefix-policy/variables.tf
+++ b/modules/terraform-aci-nd-ra-prefix-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-netflow-exporter/variables.tf
+++ b/modules/terraform-aci-netflow-exporter/variables.tf
@@ -80,8 +80,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -113,8 +113,8 @@ variable "vrf" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.vrf))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.vrf))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-ospf-interface-policy/variables.tf
+++ b/modules/terraform-aci-ospf-interface-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-ospf-route-summarization-policy/variables.tf
+++ b/modules/terraform-aci-ospf-route-summarization-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-ospf-timer-policy/variables.tf
+++ b/modules/terraform-aci-ospf-timer-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-pim-policy/variables.tf
+++ b/modules/terraform-aci-pim-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-qos-policy/variables.tf
+++ b/modules/terraform-aci-qos-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-redirect-backup-policy/variables.tf
+++ b/modules/terraform-aci-redirect-backup-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-redirect-health-group/variables.tf
+++ b/modules/terraform-aci-redirect-health-group/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-redirect-policy/variables.tf
+++ b/modules/terraform-aci-redirect-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-route-control-route-map/variables.tf
+++ b/modules/terraform-aci-route-control-route-map/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-route-tag-policy/variables.tf
+++ b/modules/terraform-aci-route-tag-policy/variables.tf
@@ -4,8 +4,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-service-epg-policy/variables.tf
+++ b/modules/terraform-aci-service-epg-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-service-graph-template/variables.tf
+++ b/modules/terraform-aci-service-graph-template/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-set-rule/variables.tf
+++ b/modules/terraform-aci-set-rule/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-tenant-monitoring-policy/variables.tf
+++ b/modules/terraform-aci-tenant-monitoring-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-tenant-netflow-exporter/variables.tf
+++ b/modules/terraform-aci-tenant-netflow-exporter/variables.tf
@@ -4,8 +4,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -114,8 +114,8 @@ variable "vrf" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.vrf))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.vrf))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-tenant-netflow-monitor/variables.tf
+++ b/modules/terraform-aci-tenant-netflow-monitor/variables.tf
@@ -4,8 +4,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-tenant-netflow-record/variables.tf
+++ b/modules/terraform-aci-tenant-netflow-record/variables.tf
@@ -4,8 +4,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-tenant-span-destination-group/variables.tf
+++ b/modules/terraform-aci-tenant-span-destination-group/variables.tf
@@ -4,8 +4,8 @@ variable "tenant" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-tenant-span-source-group/variables.tf
+++ b/modules/terraform-aci-tenant-span-source-group/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-tenant/variables.tf
+++ b/modules/terraform-aci-tenant/variables.tf
@@ -3,8 +3,8 @@ variable "name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -25,8 +25,8 @@ variable "alias" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.alias))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.alias))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-track-list/variables.tf
+++ b/modules/terraform-aci-track-list/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-track-member/variables.tf
+++ b/modules/terraform-aci-track-member/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-trust-control-policy/variables.tf
+++ b/modules/terraform-aci-trust-control-policy/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 

--- a/modules/terraform-aci-useg-endpoint-group/variables.tf
+++ b/modules/terraform-aci-useg-endpoint-group/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -106,8 +106,8 @@ variable "bridge_domain" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.bridge_domain))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.bridge_domain))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 

--- a/modules/terraform-aci-vrf/variables.tf
+++ b/modules/terraform-aci-vrf/variables.tf
@@ -3,8 +3,8 @@ variable "tenant" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.tenant))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.tenant))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 
@@ -13,8 +13,8 @@ variable "name" {
   type        = string
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.name))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,64}$", var.name))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 64."
   }
 }
 
@@ -35,8 +35,8 @@ variable "alias" {
   default     = ""
 
   validation {
-    condition     = can(regex("^[a-zA-Z0-9_.:-]{0,64}$", var.alias))
-    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `:`, `-`. Maximum characters: 64."
+    condition     = can(regex("^[a-zA-Z0-9_.-]{0,63}$", var.alias))
+    error_message = "Allowed characters: `a`-`z`, `A`-`Z`, `0`-`9`, `_`, `.`, `-`. Maximum characters: 63."
   }
 }
 


### PR DESCRIPTION
Fixing regex and ranges for Tenant, Ap, Ctx, EPg, BD classes. Ranges and regex are now aligned to the ones published at [Cloud APIC & APIC Object Model Documentation, Release 6.1(x)](https://developer.cisco.com/site/apic-mim-ref-api/?version=6.1(x))