### PR TITLE
Add EPG shutdown support

### DIFF
--- a/aci_tenants.tf
+++ b/aci_tenants.tf
@@ -410,6 +410,7 @@ locals {
           intra_epg_isolation         = try(epg.intra_epg_isolation, local.defaults.apic.tenants.application_profiles.endpoint_groups.intra_epg_isolation)
           proxy_arp                   = try(epg.proxy_arp, local.defaults.apic.tenants.application_profiles.endpoint_groups.proxy_arp)
           preferred_group             = try(epg.preferred_group, local.defaults.apic.tenants.application_profiles.endpoint_groups.preferred_group)
+          shutdown                    = try(epg.shutdown, local.defaults.apic.tenants.application_profiles.endpoint_groups.shutdown)
           qos_class                   = try(epg.qos_class, local.defaults.apic.tenants.application_profiles.endpoint_groups.qos_class)
           custom_qos_policy           = try("${epg.custom_qos_policy}${local.defaults.apic.tenants.policies.custom_qos.name_suffix}", "")
           bridge_domain               = try("${epg.bridge_domain}${local.defaults.apic.tenants.bridge_domains.name_suffix}", "")
@@ -561,6 +562,7 @@ module "aci_endpoint_group" {
   intra_epg_isolation         = each.value.intra_epg_isolation
   proxy_arp                   = each.value.proxy_arp
   preferred_group             = each.value.preferred_group
+  shutdown                    = each.value.shutdown
   qos_class                   = each.value.qos_class
   custom_qos_policy           = each.value.custom_qos_policy
   bridge_domain               = each.value.bridge_domain

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -1265,6 +1265,7 @@ defaults:
           proxy_arp: false
           preferred_group: false
           qos_class: unspecified
+          shutdown: false
           vmware_vmm_domains:
             u_segmentation: false
             delimiter: ""

--- a/modules/terraform-aci-endpoint-group/README.md
+++ b/modules/terraform-aci-endpoint-group/README.md
@@ -21,6 +21,7 @@ module "aci_endpoint_group" {
   flood_in_encap              = false
   intra_epg_isolation         = true
   preferred_group             = true
+  shutdown                    = false
   qos_class                   = "level1"
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"
@@ -147,6 +148,7 @@ module "aci_endpoint_group" {
 | <a name="input_intra_epg_isolation"></a> [intra\_epg\_isolation](#input\_intra\_epg\_isolation) | Intra EPG isolation. | `bool` | `false` | no |
 | <a name="input_proxy_arp"></a> [proxy\_arp](#input\_proxy\_arp) | Proxy-ARP | `bool` | `false` | no |
 | <a name="input_preferred_group"></a> [preferred\_group](#input\_preferred\_group) | Preferred group membership. | `bool` | `false` | no |
+| <a name="input_shutdown"></a> [shutdown](#input\_shutdown) | Shutdown. | `bool` | `false` | no |
 | <a name="input_qos_class"></a> [qos\_class](#input\_qos\_class) | QoS class. | `string` | `"unspecified"` | no |
 | <a name="input_custom_qos_policy"></a> [custom\_qos\_policy](#input\_custom\_qos\_policy) | Custom QoS policy name. | `string` | `""` | no |
 | <a name="input_bridge_domain"></a> [bridge\_domain](#input\_bridge\_domain) | Bridge domain name. | `string` | n/a | yes |

--- a/modules/terraform-aci-endpoint-group/examples/complete/README.md
+++ b/modules/terraform-aci-endpoint-group/examples/complete/README.md
@@ -24,6 +24,7 @@ module "aci_endpoint_group" {
   flood_in_encap              = false
   intra_epg_isolation         = true
   preferred_group             = true
+  shutdown                    = false
   qos_class                   = "level1"
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"

--- a/modules/terraform-aci-endpoint-group/examples/complete/main.tf
+++ b/modules/terraform-aci-endpoint-group/examples/complete/main.tf
@@ -10,6 +10,7 @@ module "aci_endpoint_group" {
   flood_in_encap              = false
   intra_epg_isolation         = true
   preferred_group             = true
+  shutdown                    = false
   qos_class                   = "level1"
   custom_qos_policy           = "CQP1"
   bridge_domain               = "BD1"

--- a/modules/terraform-aci-endpoint-group/main.tf
+++ b/modules/terraform-aci-endpoint-group/main.tf
@@ -39,6 +39,7 @@ resource "aci_rest_managed" "fvAEPg" {
     fwdCtrl      = var.proxy_arp ? "proxy-arp" : ""
     prefGrMemb   = var.preferred_group == true ? "include" : "exclude"
     prio         = var.qos_class
+    shutdown     = var.shutdown == true ? "yes" : "no"
   }
 
   dynamic "child" {

--- a/modules/terraform-aci-endpoint-group/variables.tf
+++ b/modules/terraform-aci-endpoint-group/variables.tf
@@ -85,6 +85,12 @@ variable "preferred_group" {
   default     = false
 }
 
+variable "shutdown" {
+  description = "Shutdown."
+  type        = bool
+  default     = false
+}
+
 variable "qos_class" {
   description = "QoS class."
   type        = string


### PR DESCRIPTION
Data model:

```yaml
apic:
  tenants:
    - name: ABC
      application_profiles:
        - name: AP1
          endpoint_groups:
            - name: EPG1
              bridge_domain: BD1
              shutdown: true
            - name: EPG2
              bridge_domain: BD1
            - name: EPG3
              bridge_domain: BD1
              shutdown: false
```